### PR TITLE
Update README.md for gradle dependency example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Example for Maven:
 <dependency>
     <groupId>io.reactivex</groupId>
     <artifactId>rxandroid</artifactId>
-    <version>0.22</version>
+    <version>0.22.0</version>
 </dependency>
 ```
 
 and for Ivy:
 
 ```xml
-<dependency org="io.reactivex" name="rxandroid" rev="0.22" />
+<dependency org="io.reactivex" name="rxandroid" rev="0.22.0" />
 ```
 
 and for Gradle:


### PR DESCRIPTION
Was looking to experiment with rxandroid on a project, and couldn't get the dependency to compile properly. Turns out that it is available under 0.22.0; trying to make an ad-hoc gradle dependency kept failing. I've added a line to the readme for users to be able to support those working in Android Studio that want to try rxandroid.
