### PR TITLE
Build fix: Follow alwaysTrue() move

### DIFF
--- a/src/main/java/rx/android/operators/OperatorConditionalBinding.java
+++ b/src/main/java/rx/android/operators/OperatorConditionalBinding.java
@@ -16,7 +16,7 @@ package rx.android.operators;
 import rx.Observable;
 import rx.Subscriber;
 import rx.functions.Func1;
-import rx.functions.Functions;
+import rx.internal.util.UtilityFunctions;
 
 import android.util.Log;
 
@@ -44,7 +44,7 @@ public final class OperatorConditionalBinding<T, R> implements Observable.Operat
 
     public OperatorConditionalBinding(R bound) {
         boundRef = bound;
-        this.predicate = Functions.alwaysTrue();
+        this.predicate = UtilityFunctions.alwaysTrue();
     }
 
     @Override

--- a/src/test/java/rx/android/operators/OperatorConditionalBindingTest.java
+++ b/src/test/java/rx/android/operators/OperatorConditionalBindingTest.java
@@ -23,7 +23,7 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import rx.Subscriber;
 import rx.functions.Func1;
-import rx.functions.Functions;
+import rx.internal.util.UtilityFunctions;
 import rx.observers.TestSubscriber;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -65,7 +65,7 @@ public class OperatorConditionalBindingTest {
     @Test
     public void shouldUnsubscribeFromSourceSequenceWhenPredicateFailsToPass() {
         OperatorConditionalBinding<String, Object> op = new OperatorConditionalBinding<String, Object>(
-                new Object(), Functions.alwaysFalse());
+                new Object(), UtilityFunctions.alwaysFalse());
 
         Subscriber<? super String> sub = op.call(subscriber);
         sub.onNext("one");


### PR DESCRIPTION
The commit https://github.com/ReactiveX/RxJava/commit/56b9feaf moves
alwaysTrue() to UtilityFuntions. This change updates its call-sites
accordingly.
