### PR TITLE
avoid the unncessary publish of the root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,3 +11,4 @@ buildscript {
 }
 
 apply plugin: 'rxjava-project'
+bintrayUpload.enabled=false


### PR DESCRIPTION
rxproject isn't designed for multi-module projects, but we might be able to work around that.
