### PR TITLE
Include after project rename to enable intelliJ support

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,5 @@ rootProject.name='rxandroid-root'
 include 'library', 'sample-app'
 
 project(':library').name = 'rxandroid'
+
+include 'rxandroid'


### PR DESCRIPTION
With the new project structure IntelliJ doesn't seem to recognise renamed modules. I noticed that an include after the rename forces intelliJ to recognised them. Does anyone know if this has an impact on the build (is the include ignored by gradle since it is the same module ?).
I'm importing the new name but using the original would work as well, any preferences ?
