### PR TITLE
Add AndroidObservable#bindView()

### DIFF
--- a/rxandroid/src/main/java/rx/android/operators/OperatorViewDetachedFromWindowFirst.java
+++ b/rxandroid/src/main/java/rx/android/operators/OperatorViewDetachedFromWindowFirst.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.operators;
+
+import android.view.View;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+
+/**
+ * An internal class that is used from #{@link rx.android.observables.AndroidObservable#bindView}.
+ * This emits an event when the given #{@code View} is detached from the window for the first time.
+ */
+public class OperatorViewDetachedFromWindowFirst implements Observable.OnSubscribe<View> {
+    private final View view;
+
+    public OperatorViewDetachedFromWindowFirst(View view) {
+        this.view = view;
+    }
+
+    @Override
+    public void call(final Subscriber<? super View> subscriber) {
+        new ListenerSubscription(subscriber, view);
+    }
+
+    // This could be split into a couple of anonymous classes.
+    // We pack it into one for the sake of memory efficiency.
+    private static class ListenerSubscription implements View.OnAttachStateChangeListener, Subscription {
+        private Subscriber<? super View> subscriber;
+        private View view;
+
+        public ListenerSubscription(Subscriber<? super View> subscriber, View view) {
+            this.subscriber = subscriber;
+            this.view = view;
+            view.addOnAttachStateChangeListener(this);
+            subscriber.add(this);
+        }
+
+        @Override
+        public void onViewAttachedToWindow(View v) {
+        }
+
+        @Override
+        public void onViewDetachedFromWindow(View v) {
+            if (!isUnsubscribed()) {
+                Subscriber<? super View> originalSubscriber = subscriber;
+                clear();
+                originalSubscriber.onNext(v);
+                originalSubscriber.onCompleted();
+            }
+        }
+
+        @Override
+        public void unsubscribe() {
+            if (!isUnsubscribed()) {
+                clear();
+            }
+        }
+
+        @Override
+        public boolean isUnsubscribed() {
+            return view == null;
+        }
+
+        private void clear() {
+            view.removeOnAttachStateChangeListener(this);
+            view = null;
+            subscriber = null;
+        }
+    }
+}

--- a/rxandroid/src/test/java/rx/android/observables/BindViewTest.java
+++ b/rxandroid/src/test/java/rx/android/observables/BindViewTest.java
@@ -1,0 +1,130 @@
+package rx.android.observables;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import android.app.Activity;
+import android.view.View;
+import android.widget.FrameLayout;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import rx.Observer;
+import rx.Subscription;
+import rx.subjects.PublishSubject;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class BindViewTest {
+
+    private Activity activity;
+    private FrameLayout contentView;
+    private View target;
+
+    @Mock
+    private Observer<String> observer;
+    private PublishSubject<String> subject;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        subject = PublishSubject.create();
+        activity = Robolectric.buildActivity(Activity.class).create().visible().get();
+        contentView = new FrameLayout(activity);
+        activity.setContentView(contentView);
+        target = new View(activity);
+    }
+
+    @Test
+    public void viewIsNotifiedEvenBeforeAttach() {
+        AndroidObservable.bindView(target, subject).subscribe(observer);
+
+        subject.onNext("hello");
+        subject.onCompleted();
+
+        verify(observer).onNext("hello");
+        verify(observer).onCompleted();
+    }
+
+    @Test
+    public void attachedViewIsNotified() {
+        AndroidObservable.bindView(target, subject).subscribe(observer);
+        contentView.addView(target);
+
+        subject.onNext("hello");
+        subject.onCompleted();
+
+        verify(observer).onNext("hello");
+        verify(observer).onCompleted();
+    }
+
+    @Test
+    public void detachedViewIsNotNotified() {
+        AndroidObservable.bindView(target, subject).subscribe(observer);
+        contentView.addView(target);
+        contentView.removeView(target);
+
+        subject.onNext("hello");
+        subject.onCompleted();
+
+        // No onNext() here.
+        verify(observer).onCompleted();
+    }
+
+    @Test
+    public void recycledViewIsNotNotified() {
+        AndroidObservable.bindView(target, subject).subscribe(observer);
+        contentView.addView(target);
+        contentView.removeView(target);
+        contentView.addView(target);
+
+        subject.onNext("hello");
+        subject.onCompleted();
+
+        // No onNext() here.
+        verify(observer).onCompleted();
+    }
+
+    @Test
+    public void unsubscribeStopsNotifications() {
+        Subscription subscription = AndroidObservable.bindView(target, subject).subscribe(observer);
+        contentView.addView(target);
+
+        subscription.unsubscribe();
+
+        subject.onNext("hello");
+        subject.onCompleted();
+        contentView.removeView(target);
+
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void earlyUnsubscribeStopsNotifications() {
+        Subscription subscription = AndroidObservable.bindView(target, subject).subscribe(observer);
+        subscription.unsubscribe();
+
+        contentView.addView(target);
+        subject.onNext("hello");
+        subject.onCompleted();
+        contentView.removeView(target);
+
+        verifyNoMoreInteractions(observer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullViewIsNotAllowed() {
+        AndroidObservable.bindView(null, subject);
+    }
+}


### PR DESCRIPTION
bindView() is a sister of bindActivity() and bindFragment().
Thanks for View.OnAttachStateChangeListener, it doesn't require
any manual unsubscription. It frees developers from overriding
View#onDetachFromWindow().
