### PR TITLE
Make gradle setting work with 0.8.14

### DIFF
--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -29,5 +29,5 @@ android {
 }
 
 dependencies {
-    compile project(':rxandroid')
+    compile project(':library')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,2 @@
 rootProject.name='rxandroid-root'
 include 'library', 'sample-app'
-
-project(':library').name = 'rxandroid'


### PR DESCRIPTION
Apparently it doesn't handle project renaming properly.

If this works newer version of Android Studio handles, this, please let me know. I'll switch to dev channel.

I concerned that some workflow relies on the project name, but seemingly gradle-rxjava-project-plugin uses
it only as a fallback[1], so probably this is OK?

[1] https://github.com/nebula-plugins/gradle-rxjava-project-plugin/blob/master/src/main/groovy/nebula/plugin/rxjavaproject/RxJavaPublishingPlugin.groovy
