### PR TITLE
Fix observeOn() invocation order.

### DIFF
--- a/rxandroid/src/main/java/rx/android/content/ContentObservable.java
+++ b/rxandroid/src/main/java/rx/android/content/ContentObservable.java
@@ -65,7 +65,7 @@ public final class ContentObservable {
      */
     public static <T> Observable<T> bindActivity(Activity activity, Observable<T> source) {
         Assertions.assertUiThread();
-        return source.lift(new OperatorConditionalBinding<T, Activity>(activity, ACTIVITY_VALIDATOR)).observeOn(mainThread());
+        return source.observeOn(mainThread()).lift(new OperatorConditionalBinding<T, Activity>(activity, ACTIVITY_VALIDATOR));
     }
 
     /**

--- a/rxandroid/src/main/java/rx/android/content/OperatorConditionalBinding.java
+++ b/rxandroid/src/main/java/rx/android/content/OperatorConditionalBinding.java
@@ -15,6 +15,7 @@ package rx.android.content;
 
 import rx.Observable;
 import rx.Subscriber;
+import rx.android.internal.Assertions;
 import rx.functions.Func1;
 import rx.internal.util.UtilityFunctions;
 
@@ -53,6 +54,7 @@ final class OperatorConditionalBinding<T, R> implements Observable.Operator<T, T
 
             @Override
             public void onCompleted() {
+                Assertions.assertUiThread();
                 if (shouldForwardNotification()) {
                     child.onCompleted();
                 } else {
@@ -62,6 +64,7 @@ final class OperatorConditionalBinding<T, R> implements Observable.Operator<T, T
 
             @Override
             public void onError(Throwable e) {
+                Assertions.assertUiThread();
                 if (shouldForwardNotification()) {
                     child.onError(e);
                 } else {
@@ -71,6 +74,7 @@ final class OperatorConditionalBinding<T, R> implements Observable.Operator<T, T
 
             @Override
             public void onNext(T t) {
+                Assertions.assertUiThread();
                 if (shouldForwardNotification()) {
                     child.onNext(t);
                 } else {

--- a/rxandroid/src/test/java/rx/android/TestUtil.java
+++ b/rxandroid/src/test/java/rx/android/TestUtil.java
@@ -16,8 +16,17 @@ package rx.android;
 import android.view.View;
 
 import org.robolectric.Robolectric;
+import org.robolectric.util.Scheduler;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+
+import rx.Observable;
+import rx.Subscriber;
 
 public class TestUtil {
+
+    static public final String STRING_EXPECTATION = "Hello";
 
     private TestUtil() {
         throw new AssertionError("Utility class");
@@ -25,6 +34,22 @@ public class TestUtil {
 
     public static View createView() {
         return new View(Robolectric.application);
+    }
+
+    public static Observable<String> atBackgroundThread(final CountDownLatch done) {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(final Subscriber<? super String> subscriber) {
+                Executors.newSingleThreadExecutor().submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        subscriber.onNext(STRING_EXPECTATION);
+                        subscriber.onCompleted();
+                        done.countDown();
+                    }
+                });
+            }
+        });
     }
 
 }

--- a/rxandroid/src/test/java/rx/android/view/BindViewTest.java
+++ b/rxandroid/src/test/java/rx/android/view/BindViewTest.java
@@ -16,8 +16,11 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.concurrent.CountDownLatch;
+
 import rx.Observer;
 import rx.Subscription;
+import rx.android.TestUtil;
 import rx.subjects.PublishSubject;
 
 @RunWith(RobolectricTestRunner.class)
@@ -117,6 +120,18 @@ public class BindViewTest {
         contentView.removeView(target);
 
         verifyNoMoreInteractions(observer);
+    }
+
+    @Test
+    public void bindViewInDifferentThread() throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        ViewObservable.bindView(target, TestUtil.atBackgroundThread(done)).subscribe(observer);
+        done.await();
+
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+
+        verify(observer).onNext(TestUtil.STRING_EXPECTATION);
+        verify(observer).onCompleted();
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
It should be called before lift() so that the operator can observe it on the main thread.

I tried to write a test but it didn't work, presumably because Robolectric doesn't have an event loop?
