### PR TITLE
Adding support to create self closing Observables from Cursors

### DIFF
--- a/rxandroid/src/main/java/rx/android/content/ContentObservable.java
+++ b/rxandroid/src/main/java/rx/android/content/ContentObservable.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.database.Cursor;
 import android.os.Build;
 import android.os.Handler;
 
@@ -136,6 +137,15 @@ public final class ContentObservable {
      */
     public static Observable<String> fromSharedPreferencesChanges(SharedPreferences sharedPreferences){
         return Observable.create(new OnSubscribeSharedPreferenceChange(sharedPreferences));
+    }
+
+    /**
+     * Create Observable that emits the specified {@link android.database.Cursor} for each available position
+     * of the cursor moving to the next position before each call and closing the cursor whether the
+     * Observable completes or an error occurs.
+     */
+    public static Observable<Cursor> fromCursor(final Cursor cursor) {
+        return Observable.create(new OnSubscribeCursor(cursor));
     }
 
     private ContentObservable() {

--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeCursor.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeCursor.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.content;
+
+import android.database.Cursor;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * Emits a {@link android.database.Cursor} for every available position.
+ */
+final class OnSubscribeCursor implements Observable.OnSubscribe<Cursor> {
+
+    private final Cursor cursor;
+
+    OnSubscribeCursor(final Cursor cursor) {
+        this.cursor = cursor;
+    }
+
+    @Override
+    public void call(final Subscriber<? super Cursor> subscriber) {
+        try {
+            while (!subscriber.isUnsubscribed() && cursor.moveToNext()) {
+                subscriber.onNext(cursor);
+            }
+        } finally {
+            if (!cursor.isClosed()) {
+                cursor.close();
+            }
+        }
+        subscriber.onCompleted();
+    }
+
+}


### PR DESCRIPTION
An optional overriden method allows a mapper function to create
instances of a type from the Cursor as the Observable iterates
over it.

Signed-off-by: David Marques dpsmarques@gmail.com
