### PR TITLE
Move Activity and Fragment related operations to rx.android.app

### DIFF
--- a/rxandroid/src/main/java/rx/android/app/AppObservable.java
+++ b/rxandroid/src/main/java/rx/android/app/AppObservable.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.app;
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.os.Build;
+
+import rx.Observable;
+import rx.android.internal.Assertions;
+import rx.functions.Func1;
+
+import static rx.android.schedulers.AndroidSchedulers.mainThread;
+
+public final class AppObservable {
+    private AppObservable() {
+        throw new AssertionError("No instances");
+    }
+
+    static {
+        boolean supportFragmentsAvailable = false;
+        try {
+            Class.forName("android.support.v4.app.Fragment");
+            supportFragmentsAvailable = true;
+        } catch (ClassNotFoundException e) {
+        }
+
+        USES_SUPPORT_FRAGMENTS = supportFragmentsAvailable;
+    }
+
+    private static final Func1<Activity, Boolean> ACTIVITY_VALIDATOR = new Func1<Activity, Boolean>() {
+        @Override
+        public Boolean call(Activity activity) {
+            return !activity.isFinishing();
+        }
+    };
+    private static final Func1<Fragment, Boolean> FRAGMENT_VALIDATOR = new Func1<Fragment, Boolean>() {
+        @Override
+        public Boolean call(Fragment fragment) {
+            return fragment.isAdded() && !fragment.getActivity().isFinishing();
+        }
+    };
+    private static final Func1<android.support.v4.app.Fragment, Boolean> FRAGMENTV4_VALIDATOR =
+            new Func1<android.support.v4.app.Fragment, Boolean>() {
+                @Override
+                public Boolean call(android.support.v4.app.Fragment fragment) {
+                    return fragment.isAdded() && !fragment.getActivity().isFinishing();
+                }
+            };
+    public static final boolean USES_SUPPORT_FRAGMENTS;
+
+    /**
+     * Binds the given source sequence to an activity.
+     * <p>
+     * This helper will schedule the given sequence to be observed on the main UI thread and ensure
+     * that no notifications will be forwarded to the activity in case it is scheduled to finish.
+     * <p>
+     * You should unsubscribe from the returned Observable in onDestroy at the latest, in order to not
+     * leak the activity or an inner subscriber. Conversely, when the source sequence can outlive the activity,
+     * make sure to bind to new instances of the activity again, e.g. after going through configuration changes.
+     * Refer to the samples project for actual examples.
+     *
+     * @param activity the activity to bind the source sequence to
+     * @param source   the source sequence
+     */
+    public static <T> Observable<T> bindActivity(Activity activity, Observable<T> source) {
+        Assertions.assertUiThread();
+        return source.observeOn(mainThread()).lift(new OperatorConditionalBinding<T, Activity>(activity, ACTIVITY_VALIDATOR));
+    }
+
+    /**
+     * Binds the given source sequence to a fragment (native or support-v4).
+     * <p>
+     * This helper will schedule the given sequence to be observed on the main UI thread and ensure
+     * that no notifications will be forwarded to the fragment in case it gets detached from its
+     * activity or the activity is scheduled to finish.
+     * <p>
+     * You should unsubscribe from the returned Observable in onDestroy for normal fragments, or in onDestroyView
+     * for retained fragments, in order to not leak any references to the host activity or the fragment.
+     * Refer to the samples project for actual examples.
+     *
+     * @param fragment the fragment to bind the source sequence to
+     * @param source   the source sequence
+     */
+    public static <T> Observable<T> bindFragment(Object fragment, Observable<T> source) {
+        Assertions.assertUiThread();
+        final Observable<T> o = source.observeOn(mainThread());
+        if (USES_SUPPORT_FRAGMENTS && fragment instanceof android.support.v4.app.Fragment) {
+            android.support.v4.app.Fragment f = (android.support.v4.app.Fragment) fragment;
+            return o.lift(new OperatorConditionalBinding<T, android.support.v4.app.Fragment>(f, FRAGMENTV4_VALIDATOR));
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && fragment instanceof Fragment) {
+            Fragment f = (Fragment) fragment;
+            return o.lift(new OperatorConditionalBinding<T, Fragment>(f, FRAGMENT_VALIDATOR));
+        } else {
+            throw new IllegalArgumentException("Target fragment is neither a native nor support library Fragment");
+        }
+    }
+}

--- a/rxandroid/src/main/java/rx/android/app/OperatorConditionalBinding.java
+++ b/rxandroid/src/main/java/rx/android/app/OperatorConditionalBinding.java
@@ -2,16 +2,16 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.android.content;
+package rx.android.app;
 
 import rx.Observable;
 import rx.Subscriber;

--- a/rxandroid/src/main/java/rx/android/content/ContentObservable.java
+++ b/rxandroid/src/main/java/rx/android/content/ContentObservable.java
@@ -1,104 +1,30 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package rx.android.content;
 
-import android.app.Activity;
-import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.database.Cursor;
-import android.os.Build;
 import android.os.Handler;
 
 import rx.Observable;
-import rx.android.internal.Assertions;
-import rx.functions.Func1;
-
-import static rx.android.schedulers.AndroidSchedulers.mainThread;
 
 public final class ContentObservable {
     private ContentObservable() {
         throw new AssertionError("No instances");
-    }
-
-    private static final Func1<Activity, Boolean> ACTIVITY_VALIDATOR = new Func1<Activity, Boolean>() {
-        @Override
-        public Boolean call(Activity activity) {
-            return !activity.isFinishing();
-        }
-    };
-    private static final Func1<Fragment, Boolean> FRAGMENT_VALIDATOR = new Func1<Fragment, Boolean>() {
-        @Override
-        public Boolean call(Fragment fragment) {
-            return fragment.isAdded() && !fragment.getActivity().isFinishing();
-        }
-    };
-    private static final Func1<android.support.v4.app.Fragment, Boolean> FRAGMENTV4_VALIDATOR =
-            new Func1<android.support.v4.app.Fragment, Boolean>() {
-                @Override
-                public Boolean call(android.support.v4.app.Fragment fragment) {
-                    return fragment.isAdded() && !fragment.getActivity().isFinishing();
-                }
-            };
-
-    private static final boolean USES_SUPPORT_FRAGMENTS;
-
-    static {
-        boolean supportFragmentsAvailable = false;
-        try {
-            Class.forName("android.support.v4.app.Fragment");
-            supportFragmentsAvailable = true;
-        } catch (ClassNotFoundException e) {
-        }
-
-        USES_SUPPORT_FRAGMENTS = supportFragmentsAvailable;
-    }
-
-    /**
-     * Binds the given source sequence to an activity.
-     * <p>
-     * This helper will schedule the given sequence to be observed on the main UI thread and ensure
-     * that no notifications will be forwarded to the activity in case it is scheduled to finish.
-     * <p>
-     * You should unsubscribe from the returned Observable in onDestroy at the latest, in order to not
-     * leak the activity or an inner subscriber. Conversely, when the source sequence can outlive the activity,
-     * make sure to bind to new instances of the activity again, e.g. after going through configuration changes.
-     * Refer to the samples project for actual examples.
-     *
-     * @param activity the activity to bind the source sequence to
-     * @param source   the source sequence
-     */
-    public static <T> Observable<T> bindActivity(Activity activity, Observable<T> source) {
-        Assertions.assertUiThread();
-        return source.observeOn(mainThread()).lift(new OperatorConditionalBinding<T, Activity>(activity, ACTIVITY_VALIDATOR));
-    }
-
-    /**
-     * Binds the given source sequence to a fragment (native or support-v4).
-     * <p>
-     * This helper will schedule the given sequence to be observed on the main UI thread and ensure
-     * that no notifications will be forwarded to the fragment in case it gets detached from its
-     * activity or the activity is scheduled to finish.
-     * <p>
-     * You should unsubscribe from the returned Observable in onDestroy for normal fragments, or in onDestroyView
-     * for retained fragments, in order to not leak any references to the host activity or the fragment.
-     * Refer to the samples project for actual examples.
-     *
-     * @param fragment the fragment to bind the source sequence to
-     * @param source   the source sequence
-     */
-    public static <T> Observable<T> bindFragment(Object fragment, Observable<T> source) {
-        Assertions.assertUiThread();
-        final Observable<T> o = source.observeOn(mainThread());
-        if (USES_SUPPORT_FRAGMENTS && fragment instanceof android.support.v4.app.Fragment) {
-            android.support.v4.app.Fragment f = (android.support.v4.app.Fragment) fragment;
-            return o.lift(new OperatorConditionalBinding<T, android.support.v4.app.Fragment>(f, FRAGMENTV4_VALIDATOR));
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB && fragment instanceof Fragment) {
-            Fragment f = (Fragment) fragment;
-            return o.lift(new OperatorConditionalBinding<T, Fragment>(f, FRAGMENT_VALIDATOR));
-        } else {
-            throw new IllegalArgumentException("Target fragment is neither a native nor support library Fragment");
-        }
     }
 
     /**

--- a/rxandroid/src/main/java/rx/android/view/ViewObservable.java
+++ b/rxandroid/src/main/java/rx/android/view/ViewObservable.java
@@ -39,7 +39,7 @@ public final class ViewObservable {
      * This helper will schedule the given sequence to be observed on the main UI thread and ensure
      * that no notifications will be forwarded to the view in case it gets detached from its the window.
      * <p>
-     * Unlike {@link rx.android.content.ContentObservable#bindActivity} or {@link rx.android.content.ContentObservable#bindFragment}, you don't have to unsubscribe the returned {@code Observable}
+     * Unlike {@link rx.android.app.AppObservable#bindActivity} or {@link rx.android.app.AppObservable#bindFragment}, you don't have to unsubscribe the returned {@code Observable}
      * on the detachment. {@link #bindView} does it automatically.
      * That means that the subscriber doesn't see further sequence even if the view is recycled and
      * attached again.

--- a/rxandroid/src/test/java/rx/android/app/AppObservableTest.java
+++ b/rxandroid/src/test/java/rx/android/app/AppObservableTest.java
@@ -1,0 +1,156 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.app;
+
+
+import android.app.Activity;
+import android.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import rx.Observable;
+import rx.Observer;
+import rx.android.TestUtil;
+import rx.observers.TestObserver;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class AppObservableTest {
+    // support library fragments
+    private FragmentActivity fragmentActivity;
+    private android.support.v4.app.Fragment supportFragment;
+
+    // native fragments
+    private Activity activity;
+    private Fragment fragment;
+
+    @Mock
+    private Observer<String> observer;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        supportFragment = new android.support.v4.app.Fragment();
+        fragmentActivity = Robolectric.buildActivity(FragmentActivity.class).create().get();
+        fragmentActivity.getSupportFragmentManager().beginTransaction().add(supportFragment, null).commit();
+
+        fragment = new Fragment();
+        activity = Robolectric.buildActivity(Activity.class).create().get();
+        activity.getFragmentManager().beginTransaction().add(fragment, null).commit();
+    }
+
+    @Test
+    public void itSupportsFragmentsFromTheSupportV4Library() {
+        AppObservable.bindFragment(supportFragment, Observable.just("success")).subscribe(new TestObserver<String>(observer));
+        verify(observer).onNext("success");
+        verify(observer).onCompleted();
+    }
+
+    @Test
+    public void itSupportsNativeFragments() {
+        AppObservable.bindFragment(fragment, Observable.just("success")).subscribe(new TestObserver<String>(observer));
+        verify(observer).onNext("success");
+        verify(observer).onCompleted();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void itThrowsIfObjectPassedIsNotAFragment() {
+        AppObservable.bindFragment("not a fragment", Observable.never());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void itThrowsIfObserverCallsFromFragmentFromBackgroundThread() throws Throwable {
+        final Future<Object> future = Executors.newSingleThreadExecutor().submit(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                AppObservable.bindFragment(fragment, Observable.empty());
+                return null;
+            }
+        });
+        try {
+            future.get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    public void bindFragmentToSourceFromDifferentThread() throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        AppObservable.bindFragment(fragment, TestUtil.atBackgroundThread(done)).subscribe(new TestObserver<String>(observer));
+        done.await();
+
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+
+        verify(observer).onNext(TestUtil.STRING_EXPECTATION);
+        verify(observer).onCompleted();
+    }
+
+    @Test
+    public void bindSupportFragmentToSourceFromDifferentThread() throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        AppObservable.bindFragment(supportFragment, TestUtil.atBackgroundThread(done)).subscribe(new TestObserver<String>(observer));
+        done.await();
+
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+
+        verify(observer).onNext(TestUtil.STRING_EXPECTATION);
+        verify(observer).onCompleted();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void itThrowsIfObserverCallsFromActivityFromBackgroundThread() throws Throwable {
+        final Future<Object> future = Executors.newSingleThreadExecutor().submit(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                AppObservable.bindActivity(activity, Observable.empty());
+                return null;
+            }
+        });
+        try {
+            future.get(1, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
+    @Test
+    public void bindActivityToSourceFromDifferentThread() throws InterruptedException {
+        CountDownLatch done = new CountDownLatch(1);
+        AppObservable.bindActivity(activity, TestUtil.atBackgroundThread(done)).subscribe(new TestObserver<String>(observer));
+        done.await();
+
+        Robolectric.runUiThreadTasksIncludingDelayedTasks();
+
+        verify(observer).onNext(TestUtil.STRING_EXPECTATION);
+        verify(observer).onCompleted();
+    }
+}

--- a/rxandroid/src/test/java/rx/android/app/OperatorConditionalBindingTest.java
+++ b/rxandroid/src/test/java/rx/android/app/OperatorConditionalBindingTest.java
@@ -2,16 +2,16 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.android.content;
+package rx.android.app;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import rx.Subscriber;
-import rx.android.content.OperatorConditionalBinding;
+import rx.android.app.OperatorConditionalBinding;
 import rx.functions.Func1;
 import rx.internal.util.UtilityFunctions;
 import rx.observers.TestSubscriber;

--- a/rxandroid/src/test/java/rx/android/content/ContentObservableTest.java
+++ b/rxandroid/src/test/java/rx/android/content/ContentObservableTest.java
@@ -13,33 +13,16 @@
  */
 package rx.android.content;
 
-import android.app.Activity;
-import android.app.Fragment;
 import android.database.Cursor;
-import android.support.v4.app.FragmentActivity;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
 import rx.Observable;
-import rx.Observer;
 import rx.Subscriber;
-import rx.android.TestUtil;
-import rx.observers.TestObserver;
 import rx.observers.TestSubscriber;
 
 import static org.mockito.Mockito.doThrow;
@@ -54,118 +37,6 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class ContentObservableTest {
-
-    // support library fragments
-    private FragmentActivity fragmentActivity;
-    private android.support.v4.app.Fragment supportFragment;
-
-    // native fragments
-    private Activity activity;
-    private Fragment fragment;
-
-    @Mock
-    private Observer<String> observer;
-
-    @Before
-    public void setup() {
-        MockitoAnnotations.initMocks(this);
-        supportFragment = new android.support.v4.app.Fragment();
-        fragmentActivity = Robolectric.buildActivity(FragmentActivity.class).create().get();
-        fragmentActivity.getSupportFragmentManager().beginTransaction().add(supportFragment, null).commit();
-
-        fragment = new Fragment();
-        activity = Robolectric.buildActivity(Activity.class).create().get();
-        activity.getFragmentManager().beginTransaction().add(fragment, null).commit();
-    }
-
-    @Test
-    public void itSupportsFragmentsFromTheSupportV4Library() {
-        ContentObservable.bindFragment(supportFragment, Observable.just("success")).subscribe(new TestObserver<String>(observer));
-        verify(observer).onNext("success");
-        verify(observer).onCompleted();
-    }
-
-    @Test
-    public void itSupportsNativeFragments() {
-        ContentObservable.bindFragment(fragment, Observable.just("success")).subscribe(new TestObserver<String>(observer));
-        verify(observer).onNext("success");
-        verify(observer).onCompleted();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void itThrowsIfObjectPassedIsNotAFragment() {
-        ContentObservable.bindFragment("not a fragment", Observable.never());
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void itThrowsIfObserverCallsFromFragmentFromBackgroundThread() throws Throwable {
-        final Future<Object> future = Executors.newSingleThreadExecutor().submit(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                ContentObservable.bindFragment(fragment, Observable.empty());
-                return null;
-            }
-        });
-        try {
-            future.get(1, TimeUnit.SECONDS);
-        } catch (ExecutionException e) {
-            throw e.getCause();
-        }
-    }
-
-    @Test
-    public void bindFragmentToSourceFromDifferentThread() throws InterruptedException {
-        CountDownLatch done = new CountDownLatch(1);
-        ContentObservable.bindFragment(fragment, TestUtil.atBackgroundThread(done)).subscribe(new TestObserver<String>(observer));
-        done.await();
-
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
-
-        verify(observer).onNext(TestUtil.STRING_EXPECTATION);
-        verify(observer).onCompleted();
-    }
-
-    @Test
-    public void bindSupportFragmentToSourceFromDifferentThread() throws InterruptedException {
-        CountDownLatch done = new CountDownLatch(1);
-        ContentObservable.bindFragment(supportFragment, TestUtil.atBackgroundThread(done)).subscribe(new TestObserver<String>(observer));
-        done.await();
-
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
-
-        verify(observer).onNext(TestUtil.STRING_EXPECTATION);
-        verify(observer).onCompleted();
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void itThrowsIfObserverCallsFromActivityFromBackgroundThread() throws Throwable {
-        final Future<Object> future = Executors.newSingleThreadExecutor().submit(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                ContentObservable.bindActivity(activity, Observable.empty());
-                return null;
-            }
-        });
-        try {
-            future.get(1, TimeUnit.SECONDS);
-        } catch (ExecutionException e) {
-            throw e.getCause();
-        }
-    }
-
-    @Test
-    public void bindActivityToSourceFromDifferentThread() throws InterruptedException {
-        CountDownLatch done = new CountDownLatch(1);
-        ContentObservable.bindActivity(activity, TestUtil.atBackgroundThread(done)).subscribe(new TestObserver<String>(observer));
-        done.await();
-
-        Robolectric.runUiThreadTasksIncludingDelayedTasks();
-
-        verify(observer).onNext(TestUtil.STRING_EXPECTATION);
-        verify(observer).onCompleted();
-    }
-
-
     public void givenCursorWhenFromCursorInvokedThenObservableCallsOnNextWhileHasNext() {
         final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
         final Cursor cursor = mock(Cursor.class);

--- a/sample-app/src/main/java/rx/android/samples/ListFragmentActivity.java
+++ b/sample-app/src/main/java/rx/android/samples/ListFragmentActivity.java
@@ -11,7 +11,7 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import rx.Observable;
 import rx.Subscriber;
-import rx.android.content.ContentObservable;
+import rx.android.app.AppObservable;
 import rx.android.widget.OnListViewScrollEvent;
 import rx.android.widget.WidgetObservable;
 import rx.functions.Action1;
@@ -54,13 +54,13 @@ public class ListFragmentActivity extends Activity {
             ListView listView = (ListView) view.findViewById(android.R.id.list);
             listView.setAdapter(adapter);
 
-            ContentObservable.bindFragment(this, SampleObservables.numberStrings(1, 500, 100))
+            AppObservable.bindFragment(this, SampleObservables.numberStrings(1, 500, 100))
                 .observeOn(mainThread())
                 .lift(new BindAdapter())
                 .subscribe();
 
             final ProgressBar progressBar = (ProgressBar) view.findViewById(android.R.id.progress);
-            ContentObservable.bindFragment(this, WidgetObservable.listScrollEvents(listView))
+            AppObservable.bindFragment(this, WidgetObservable.listScrollEvents(listView))
                 .subscribe(new Action1<OnListViewScrollEvent>() {
                     @Override
                     public void call(OnListViewScrollEvent event) {

--- a/sample-app/src/main/java/rx/android/samples/ListenInOutActivity.java
+++ b/sample-app/src/main/java/rx/android/samples/ListenInOutActivity.java
@@ -12,7 +12,7 @@ import rx.Observer;
 import rx.Subscription;
 import rx.observables.ConnectableObservable;
 
-import static rx.android.content.ContentObservable.bindActivity;
+import static rx.android.app.AppObservable.bindActivity;
 
 /**
  * Activity that binds to a counting sequence and is able to listen in and out to that

--- a/sample-app/src/main/java/rx/android/samples/ListeningFragmentActivity.java
+++ b/sample-app/src/main/java/rx/android/samples/ListeningFragmentActivity.java
@@ -11,7 +11,7 @@ import android.widget.Toast;
 
 import rx.Subscriber;
 import rx.Subscription;
-import rx.android.content.ContentObservable;
+import rx.android.app.AppObservable;
 import rx.observables.ConnectableObservable;
 import rx.subscriptions.Subscriptions;
 
@@ -74,7 +74,7 @@ public class ListeningFragmentActivity extends Activity {
             final TextView textView = (TextView) view.findViewById(android.R.id.text1);
 
             // re-connect to sequence
-            subscription = ContentObservable.bindFragment(this, strings).subscribe(new Subscriber<String>() {
+            subscription = AppObservable.bindFragment(this, strings).subscribe(new Subscriber<String>() {
 
                 @Override
                 public void onCompleted() {

--- a/sample-app/src/main/java/rx/android/samples/RetainedFragmentActivity.java
+++ b/sample-app/src/main/java/rx/android/samples/RetainedFragmentActivity.java
@@ -18,7 +18,7 @@ import rx.functions.Action1;
 import rx.functions.Func1;
 import rx.subscriptions.Subscriptions;
 
-import static rx.android.content.ContentObservable.bindFragment;
+import static rx.android.app.AppObservable.bindFragment;
 
 /**
  * Problem:


### PR DESCRIPTION
@mttkay As you wondered at #84, you're right. They should be in rx.android.app.
