### PR TITLE
Reverted some View and Widget Observables to use simple objects instead of Event objects

### DIFF
--- a/rxandroid/src/main/java/rx/android/view/OnCheckedChangeEvent.java
+++ b/rxandroid/src/main/java/rx/android/view/OnCheckedChangeEvent.java
@@ -16,6 +16,8 @@ package rx.android.view;
 import android.widget.CompoundButton;
 import com.google.auto.value.AutoValue;
 
+/** @deprecated this class will be removed soon */
+@Deprecated
 @AutoValue
 public abstract class OnCheckedChangeEvent {
     public abstract CompoundButton view();

--- a/rxandroid/src/main/java/rx/android/view/OnClickEvent.java
+++ b/rxandroid/src/main/java/rx/android/view/OnClickEvent.java
@@ -17,6 +17,8 @@ import android.view.View;
 
 import com.google.auto.value.AutoValue;
 
+/** @deprecated this class will be removed soon */
+@Deprecated
 @AutoValue
 public abstract class OnClickEvent {
     public abstract View view();

--- a/rxandroid/src/main/java/rx/android/view/OnSubscribeViewClickOld.java
+++ b/rxandroid/src/main/java/rx/android/view/OnSubscribeViewClickOld.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.view;
+
+import android.view.View;
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.android.internal.Assertions;
+import rx.android.AndroidSubscriptions;
+import rx.functions.Action0;
+
+/** @deprecated this class will be removed soon */
+@Deprecated
+final class OnSubscribeViewClickOld implements Observable.OnSubscribe<OnClickEvent> {
+    private final boolean emitInitialValue;
+    private final View view;
+
+    public OnSubscribeViewClickOld(final View view, final boolean emitInitialValue) {
+        this.emitInitialValue = emitInitialValue;
+        this.view = view;
+    }
+
+    @Override
+    public void call(final Subscriber<? super OnClickEvent> observer) {
+        Assertions.assertUiThread();
+        final OnSubscribeViewClick.CompositeOnClickListener composite = OnSubscribeViewClick.CachedListeners.getFromViewOrCreate(view);
+
+        final View.OnClickListener listener = new View.OnClickListener() {
+            @Override
+            public void onClick(final View clicked) {
+                observer.onNext(OnClickEvent.create(view));
+            }
+        };
+
+        final Subscription subscription = AndroidSubscriptions.unsubscribeInUiThread(new Action0() {
+            @Override
+            public void call() {
+                composite.removeOnClickListener(listener);
+            }
+        });
+
+        if (emitInitialValue) {
+            observer.onNext(OnClickEvent.create(view));
+        }
+
+        composite.addOnClickListener(listener);
+        observer.add(subscription);
+    }
+}

--- a/rxandroid/src/main/java/rx/android/view/ViewObservable.java
+++ b/rxandroid/src/main/java/rx/android/view/ViewObservable.java
@@ -26,12 +26,24 @@ public final class ViewObservable {
         throw new AssertionError("No instances");
     }
 
+    /** @deprecated this method will soon be replaced by renamed {@link #forClicks} */
+    @Deprecated
     public static Observable<OnClickEvent> clicks(final View view) {
         return clicks(view, false);
     }
 
+    /** @deprecated this method will soon be replaced by renamed {@link #forClicks} */
+    @Deprecated
     public static Observable<OnClickEvent> clicks(final View view, final boolean emitInitialValue) {
-        return Observable.create(new OnSubscribeViewClick(view, emitInitialValue));
+        return Observable.create(new OnSubscribeViewClickOld(view, emitInitialValue));
+    }
+
+    public static <T extends View> Observable<T> forClicks(final T view, final boolean emitInitialValue) {
+        return Observable.create(new OnSubscribeViewClick<T>(view, emitInitialValue));
+    }
+
+    public static <T extends View> Observable<T> forClicks(final T view) {
+        return forClicks(view, false);
     }
 
     /**

--- a/rxandroid/src/main/java/rx/android/widget/OnSubscribeCompoundButtonInputOld.java
+++ b/rxandroid/src/main/java/rx/android/widget/OnSubscribeCompoundButtonInputOld.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.widget;
+
+import android.widget.CompoundButton;
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.android.view.OnCheckedChangeEvent;
+import rx.android.internal.Assertions;
+import rx.android.AndroidSubscriptions;
+import rx.functions.Action0;
+
+/** @deprecated this class will be removed soon */
+@Deprecated
+class OnSubscribeCompoundButtonInputOld implements Observable.OnSubscribe<OnCheckedChangeEvent> {
+    private final boolean emitInitialValue;
+    private final CompoundButton button;
+
+    public OnSubscribeCompoundButtonInputOld(final CompoundButton button, final boolean emitInitialValue) {
+        this.emitInitialValue = emitInitialValue;
+        this.button = button;
+    }
+
+    @Override
+    public void call(final Subscriber<? super OnCheckedChangeEvent> observer) {
+        Assertions.assertUiThread();
+        final OnSubscribeCompoundButtonInput.CompositeOnCheckedChangeListener composite =
+                OnSubscribeCompoundButtonInput.CachedListeners.getFromViewOrCreate(button);
+
+        final CompoundButton.OnCheckedChangeListener listener = new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(final CompoundButton view, final boolean checked) {
+                observer.onNext(OnCheckedChangeEvent.create(button, checked));
+            }
+        };
+
+        final Subscription subscription = AndroidSubscriptions.unsubscribeInUiThread(new Action0() {
+            @Override
+            public void call() {
+                composite.removeOnCheckedChangeListener(listener);
+            }
+        });
+
+        if (emitInitialValue) {
+            observer.onNext(OnCheckedChangeEvent.create(button));
+        }
+
+        composite.addOnCheckedChangeListener(listener);
+        observer.add(subscription);
+    }
+}
+
+

--- a/rxandroid/src/main/java/rx/android/widget/OnSubscribeTextViewInputOld.java
+++ b/rxandroid/src/main/java/rx/android/widget/OnSubscribeTextViewInputOld.java
@@ -13,32 +13,34 @@
  */
 package rx.android.widget;
 
-import android.text.Editable;
-import android.text.TextWatcher;
-import android.widget.TextView;
 import rx.Observable;
 import rx.Subscriber;
 import rx.Subscription;
-import rx.android.AndroidSubscriptions;
 import rx.android.internal.Assertions;
+import rx.android.AndroidSubscriptions;
 import rx.functions.Action0;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.TextView;
 
-class OnSubscribeTextViewInput<T extends TextView> implements Observable.OnSubscribe<T> {
+/** @deprecated this class will be removed soon */
+@Deprecated
+class OnSubscribeTextViewInputOld implements Observable.OnSubscribe<OnTextChangeEvent> {
     private final boolean emitInitialValue;
-    private final T input;
+    private final TextView input;
 
-    public OnSubscribeTextViewInput(final T input, final boolean emitInitialValue) {
+    public OnSubscribeTextViewInputOld(final TextView input, final boolean emitInitialValue) {
         this.input = input;
         this.emitInitialValue = emitInitialValue;
     }
 
     @Override
-    public void call(final Subscriber<? super T> observer) {
+    public void call(final Subscriber<? super OnTextChangeEvent> observer) {
         Assertions.assertUiThread();
-        final TextWatcher watcher = new SimpleTextWatcher() {
+        final TextWatcher watcher = new OnSubscribeTextViewInput.SimpleTextWatcher() {
             @Override
             public void afterTextChanged(final Editable editable) {
-                observer.onNext(input);
+                observer.onNext(OnTextChangeEvent.create(input));
             }
         };
 
@@ -50,28 +52,11 @@ class OnSubscribeTextViewInput<T extends TextView> implements Observable.OnSubsc
         });
 
         if (emitInitialValue) {
-            observer.onNext(input);
+            observer.onNext(OnTextChangeEvent.create(input));
         }
 
         input.addTextChangedListener(watcher);
         observer.add(subscription);
-    }
-
-    static class SimpleTextWatcher implements TextWatcher {
-        @Override
-        public void beforeTextChanged(final CharSequence sequence, final int start, final int count, final int after) {
-            // nothing to do
-        }
-
-        @Override
-        public void onTextChanged(final CharSequence sequence, final int start, final int before, final int count) {
-            // nothing to do
-        }
-
-        @Override
-        public void afterTextChanged(final Editable editable) {
-            // nothing to do
-        }
     }
 }
 

--- a/rxandroid/src/main/java/rx/android/widget/OnTextChangeEvent.java
+++ b/rxandroid/src/main/java/rx/android/widget/OnTextChangeEvent.java
@@ -18,6 +18,8 @@ import android.widget.TextView;
 
 import com.google.auto.value.AutoValue;
 
+/** @deprecated this class will be removed soon */
+@Deprecated
 @AutoValue
 public abstract class OnTextChangeEvent {
     public abstract TextView view();

--- a/rxandroid/src/main/java/rx/android/widget/WidgetObservable.java
+++ b/rxandroid/src/main/java/rx/android/widget/WidgetObservable.java
@@ -1,3 +1,16 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package rx.android.widget;
 
 import android.widget.AbsListView;
@@ -13,20 +26,44 @@ public final class WidgetObservable {
         throw new AssertionError("No instances");
     }
 
+    /** @deprecated this method will soon be replaced by renamed {@link #forText} */
+    @Deprecated
     public static Observable<OnTextChangeEvent> text(final TextView input) {
         return text(input, false);
     }
 
+    /** @deprecated this method will soon be replaced by renamed {@link #forText} */
+    @Deprecated
     public static Observable<OnTextChangeEvent> text(final TextView input, final boolean emitInitialValue) {
-        return Observable.create(new OnSubscribeTextViewInput(input, emitInitialValue));
+        return Observable.create(new OnSubscribeTextViewInputOld(input, emitInitialValue));
     }
 
+    public static <T extends TextView> Observable<T> forText(final T textView) {
+        return forText(textView, false);
+    }
+
+    public static <T extends TextView> Observable<T> forText(final T textView, final boolean emitInitialValue) {
+        return Observable.create(new OnSubscribeTextViewInput<T>(textView, emitInitialValue));
+    }
+
+    /** @deprecated this method will soon be removed, use {@link #toggle} instead */
+    @Deprecated
     public static Observable<OnCheckedChangeEvent> input(final CompoundButton button) {
         return input(button, false);
     }
 
+    /** @deprecated this method will soon be removed, use {@link #toggle} instead */
+    @Deprecated
     public static Observable<OnCheckedChangeEvent> input(final CompoundButton button, final boolean emitInitialValue) {
-        return Observable.create(new OnSubscribeCompoundButtonInput(button, emitInitialValue));
+        return Observable.create(new OnSubscribeCompoundButtonInputOld(button, emitInitialValue));
+    }
+
+    public static Observable<Boolean> toggle(final CompoundButton view) {
+        return toggle(view, false);
+    }
+
+    public static Observable<Boolean> toggle(final CompoundButton view, final boolean emitInitialValue) {
+        return Observable.create(new OnSubscribeCompoundButtonInput(view, emitInitialValue));
     }
 
     public static Observable<OnItemClickEvent> itemClicks(final AdapterView<?> adapterView) {

--- a/rxandroid/src/test/java/rx/android/app/OperatorConditionalBindingTest.java
+++ b/rxandroid/src/test/java/rx/android/app/OperatorConditionalBindingTest.java
@@ -22,7 +22,6 @@ import org.junit.runner.RunWith;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import rx.Subscriber;
-import rx.android.app.OperatorConditionalBinding;
 import rx.functions.Func1;
 import rx.internal.util.UtilityFunctions;
 import rx.observers.TestSubscriber;

--- a/rxandroid/src/test/java/rx/android/content/OperatorSharedPreferencesChangeTest.java
+++ b/rxandroid/src/test/java/rx/android/content/OperatorSharedPreferencesChangeTest.java
@@ -27,7 +27,11 @@ import rx.Subscription;
 import rx.observers.TestObserver;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 public class OperatorSharedPreferencesChangeTest {

--- a/rxandroid/src/test/java/rx/android/lifecycle/OperatorSubscribeUntilTest.java
+++ b/rxandroid/src/test/java/rx/android/lifecycle/OperatorSubscribeUntilTest.java
@@ -30,7 +30,9 @@ import rx.observers.TestSubscriber;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.atLeastOnce;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)

--- a/rxandroid/src/test/java/rx/android/view/OperatorViewClickTest.java
+++ b/rxandroid/src/test/java/rx/android/view/OperatorViewClickTest.java
@@ -13,53 +13,46 @@
  */
 package rx.android.view;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.inOrder;
+
 import android.app.Activity;
 import android.view.View;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
 import rx.observers.TestObserver;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.refEq;
-import static org.mockito.Mockito.times;
-
 @RunWith(RobolectricTestRunner.class)
 public class OperatorViewClickTest {
-    private static OnClickEvent mkMockedEvent(final View view) {
-        return refEq(OnClickEvent.create(view));
-    }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testWithoutInitialValue() {
         final View view = new View(Robolectric.buildActivity(Activity.class).create().get());
-        final Observable<OnClickEvent> observable = ViewObservable.clicks(view, false);
-        final Observer<OnClickEvent> observer = mock(Observer.class);
-        final Subscription subscription = observable.subscribe(new TestObserver<OnClickEvent>(observer));
+        final Observable<View> observable = ViewObservable.forClicks(view, false);
+        final Observer<View> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<View>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, never()).onNext(any(OnClickEvent.class));
+        inOrder.verify(observer, never()).onNext(any(View.class));
 
         view.performClick();
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(view));
+        inOrder.verify(observer, times(1)).onNext(view);
 
         view.performClick();
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(view));
+        inOrder.verify(observer, times(1)).onNext(view);
 
         subscription.unsubscribe();
-        inOrder.verify(observer, never()).onNext(any(OnClickEvent.class));
+        inOrder.verify(observer, never()).onNext(any(View.class));
 
         inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verify(observer, never()).onCompleted();
@@ -69,22 +62,22 @@ public class OperatorViewClickTest {
     @SuppressWarnings("unchecked")
     public void testWithInitialValue() {
         final View view = new View(Robolectric.buildActivity(Activity.class).create().get());
-        final Observable<OnClickEvent> observable = ViewObservable.clicks(view, true);
-        final Observer<OnClickEvent> observer = mock(Observer.class);
-        final Subscription subscription = observable.subscribe(new TestObserver<OnClickEvent>(observer));
+        final Observable<View> observable = ViewObservable.forClicks(view, true);
+        final Observer<View> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<View>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(view));
+        inOrder.verify(observer, times(1)).onNext(view);
 
         view.performClick();
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(view));
+        inOrder.verify(observer, times(1)).onNext(view);
 
         view.performClick();
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(view));
+        inOrder.verify(observer, times(1)).onNext(view);
 
         subscription.unsubscribe();
-        inOrder.verify(observer, never()).onNext(any(OnClickEvent.class));
+        inOrder.verify(observer, never()).onNext(any(View.class));
 
         inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verify(observer, never()).onCompleted();
@@ -94,34 +87,34 @@ public class OperatorViewClickTest {
     @SuppressWarnings("unchecked")
     public void testMultipleSubscriptions() {
         final View view = new View(Robolectric.buildActivity(Activity.class).create().get());
-        final Observable<OnClickEvent> observable = ViewObservable.clicks(view, false);
+        final Observable<View> observable = ViewObservable.forClicks(view, false);
 
-        final Observer<OnClickEvent> observer1 = mock(Observer.class);
-        final Observer<OnClickEvent> observer2 = mock(Observer.class);
+        final Observer<View> observer1 = mock(Observer.class);
+        final Observer<View> observer2 = mock(Observer.class);
 
-        final Subscription subscription1 = observable.subscribe(new TestObserver<OnClickEvent>(observer1));
-        final Subscription subscription2 = observable.subscribe(new TestObserver<OnClickEvent>(observer2));
+        final Subscription subscription1 = observable.subscribe(new TestObserver<View>(observer1));
+        final Subscription subscription2 = observable.subscribe(new TestObserver<View>(observer2));
 
         final InOrder inOrder1 = inOrder(observer1);
         final InOrder inOrder2 = inOrder(observer2);
 
         view.performClick();
-        inOrder1.verify(observer1, times(1)).onNext(mkMockedEvent(view));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(view));
+        inOrder1.verify(observer1, times(1)).onNext(view);
+        inOrder2.verify(observer2, times(1)).onNext(view);
 
         view.performClick();
-        inOrder1.verify(observer1, times(1)).onNext(mkMockedEvent(view));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(view));
+        inOrder1.verify(observer1, times(1)).onNext(view);
+        inOrder2.verify(observer2, times(1)).onNext(view);
         subscription1.unsubscribe();
 
         view.performClick();
-        inOrder1.verify(observer1, never()).onNext(any(OnClickEvent.class));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(view));
+        inOrder1.verify(observer1, never()).onNext(any(View.class));
+        inOrder2.verify(observer2, times(1)).onNext(view);
         subscription2.unsubscribe();
 
         view.performClick();
-        inOrder1.verify(observer1, never()).onNext(any(OnClickEvent.class));
-        inOrder2.verify(observer2, never()).onNext(any(OnClickEvent.class));
+        inOrder1.verify(observer1, never()).onNext(any(View.class));
+        inOrder2.verify(observer2, never()).onNext(any(View.class));
 
         inOrder1.verify(observer1, never()).onError(any(Throwable.class));
         inOrder2.verify(observer2, never()).onError(any(Throwable.class));

--- a/rxandroid/src/test/java/rx/android/widget/OperatorCompoundButtonInputTest.java
+++ b/rxandroid/src/test/java/rx/android/widget/OperatorCompoundButtonInputTest.java
@@ -24,23 +24,19 @@ import org.robolectric.RobolectricTestRunner;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
-import rx.android.view.OnCheckedChangeEvent;
 import rx.observers.TestObserver;
 
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.refEq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.anyBoolean;
 
 @RunWith(RobolectricTestRunner.class)
 public class OperatorCompoundButtonInputTest {
-    private static OnCheckedChangeEvent mkMockedEvent(final CompoundButton button, final boolean value) {
-        return refEq(OnCheckedChangeEvent.create(button, value));
-    }
 
-    private static CompoundButton mkCompoundButton(final boolean value) {
+    private static CompoundButton createCompoundButton(final boolean value) {
         final Activity activity = Robolectric.buildActivity(Activity.class).create().get();
         final CheckBox checkbox = new CheckBox(activity);
 
@@ -51,30 +47,30 @@ public class OperatorCompoundButtonInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testWithoutInitialValue() {
-        final CompoundButton button = mkCompoundButton(true);
-        final Observable<OnCheckedChangeEvent> observable = WidgetObservable.input(button, false);
-        final Observer<OnCheckedChangeEvent> observer = mock(Observer.class);
-        final Subscription subscription = observable.subscribe(new TestObserver<OnCheckedChangeEvent>(observer));
+        final CompoundButton button = createCompoundButton(true);
+        final Observable<Boolean> observable = WidgetObservable.toggle(button, false);
+        final Observer<Boolean> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<Boolean>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, never()).onNext(any(OnCheckedChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(anyBoolean());
 
         button.setChecked(true);
-        inOrder.verify(observer, never()).onNext(any(OnCheckedChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(anyBoolean());
 
         button.setChecked(false);
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(button, false));
+        inOrder.verify(observer, times(1)).onNext(false);
 
         button.setChecked(true);
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(button, true));
+        inOrder.verify(observer, times(1)).onNext(true);
 
         button.setChecked(false);
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(button, false));
+        inOrder.verify(observer, times(1)).onNext(false);
         subscription.unsubscribe();
 
         button.setChecked(true);
-        inOrder.verify(observer, never()).onNext(any(OnCheckedChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(anyBoolean());
 
         inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verify(observer, never()).onCompleted();
@@ -83,30 +79,30 @@ public class OperatorCompoundButtonInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testWithInitialValue() {
-        final CompoundButton button = mkCompoundButton(true);
-        final Observable<OnCheckedChangeEvent> observable = WidgetObservable.input(button, true);
-        final Observer<OnCheckedChangeEvent> observer = mock(Observer.class);
-        final Subscription subscription = observable.subscribe(new TestObserver<OnCheckedChangeEvent>(observer));
+        final CompoundButton button = createCompoundButton(true);
+        final Observable<Boolean> observable = WidgetObservable.toggle(button, true);
+        final Observer<Boolean> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<Boolean>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(button, true));
+        inOrder.verify(observer, times(1)).onNext(true);
 
         button.setChecked(false);
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(button, false));
+        inOrder.verify(observer, times(1)).onNext(false);
 
         button.setChecked(true);
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(button, true));
+        inOrder.verify(observer, times(1)).onNext(true);
 
         button.setChecked(true);
-        inOrder.verify(observer, never()).onNext(any(OnCheckedChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(anyBoolean());
 
         button.setChecked(false);
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(button, false));
+        inOrder.verify(observer, times(1)).onNext(false);
         subscription.unsubscribe();
 
         button.setChecked(true);
-        inOrder.verify(observer, never()).onNext(any(OnCheckedChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(anyBoolean());
 
         inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verify(observer, never()).onCompleted();
@@ -115,35 +111,35 @@ public class OperatorCompoundButtonInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testMultipleSubscriptions() {
-        final CompoundButton button = mkCompoundButton(false);
-        final Observable<OnCheckedChangeEvent> observable = WidgetObservable.input(button, false);
+        final CompoundButton button = createCompoundButton(false);
+        final Observable<Boolean> observable = WidgetObservable.toggle(button, false);
 
-        final Observer<OnCheckedChangeEvent> observer1 = mock(Observer.class);
-        final Observer<OnCheckedChangeEvent> observer2 = mock(Observer.class);
+        final Observer<Boolean> observer1 = mock(Observer.class);
+        final Observer<Boolean> observer2 = mock(Observer.class);
 
-        final Subscription subscription1 = observable.subscribe(new TestObserver<OnCheckedChangeEvent>(observer1));
-        final Subscription subscription2 = observable.subscribe(new TestObserver<OnCheckedChangeEvent>(observer2));
+        final Subscription subscription1 = observable.subscribe(new TestObserver<Boolean>(observer1));
+        final Subscription subscription2 = observable.subscribe(new TestObserver<Boolean>(observer2));
 
         final InOrder inOrder1 = inOrder(observer1);
         final InOrder inOrder2 = inOrder(observer2);
 
         button.setChecked(true);
-        inOrder1.verify(observer1, times(1)).onNext(mkMockedEvent(button, true));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(button, true));
+        inOrder1.verify(observer1, times(1)).onNext(true);
+        inOrder2.verify(observer2, times(1)).onNext(true);
 
         button.setChecked(false);
-        inOrder1.verify(observer1, times(1)).onNext(mkMockedEvent(button, false));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(button, false));
+        inOrder1.verify(observer1, times(1)).onNext(false);
+        inOrder2.verify(observer2, times(1)).onNext(false);
         subscription1.unsubscribe();
 
         button.setChecked(true);
-        inOrder1.verify(observer1, never()).onNext(any(OnCheckedChangeEvent.class));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(button, true));
+        inOrder1.verify(observer1, never()).onNext(anyBoolean());
+        inOrder2.verify(observer2, times(1)).onNext(true);
         subscription2.unsubscribe();
 
         button.setChecked(false);
-        inOrder1.verify(observer1, never()).onNext(any(OnCheckedChangeEvent.class));
-        inOrder2.verify(observer2, never()).onNext(any(OnCheckedChangeEvent.class));
+        inOrder1.verify(observer1, never()).onNext(anyBoolean());
+        inOrder2.verify(observer2, never()).onNext(anyBoolean());
 
         inOrder1.verify(observer1, never()).onError(any(Throwable.class));
         inOrder1.verify(observer1, never()).onCompleted();

--- a/rxandroid/src/test/java/rx/android/widget/OperatorCompoundButtonInputTest.java
+++ b/rxandroid/src/test/java/rx/android/widget/OperatorCompoundButtonInputTest.java
@@ -27,7 +27,12 @@ import rx.Subscription;
 import rx.android.view.OnCheckedChangeEvent;
 import rx.observers.TestObserver;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.refEq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 public class OperatorCompoundButtonInputTest {

--- a/rxandroid/src/test/java/rx/android/widget/OperatorTextViewInputTest.java
+++ b/rxandroid/src/test/java/rx/android/widget/OperatorTextViewInputTest.java
@@ -29,7 +29,11 @@ import rx.Subscription;
 import rx.observers.TestObserver;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.argThat;
 
 @RunWith(RobolectricTestRunner.class)
 public class OperatorTextViewInputTest {

--- a/rxandroid/src/test/java/rx/android/widget/OperatorTextViewInputTest.java
+++ b/rxandroid/src/test/java/rx/android/widget/OperatorTextViewInputTest.java
@@ -13,50 +13,31 @@
  */
 package rx.android.widget;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.times;
+
 import android.app.Activity;
-import android.text.TextUtils;
 import android.widget.EditText;
 import android.widget.TextView;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import rx.Observable;
 import rx.Observer;
 import rx.Subscription;
+import rx.functions.Func1;
 import rx.observers.TestObserver;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.argThat;
 
 @RunWith(RobolectricTestRunner.class)
 public class OperatorTextViewInputTest {
-    private static OnTextChangeEvent mkMockedEvent(final TextView view, final CharSequence text) {
-        return argThat(new ArgumentMatcher<OnTextChangeEvent>() {
-            @Override
-            public boolean matches(final Object argument) {
-                if (!(argument instanceof OnTextChangeEvent)) {
-                    return false;
-                }
 
-                final OnTextChangeEvent event = (OnTextChangeEvent) argument;
-
-                if (event.view() != view) {
-                    return false;
-                }
-
-                return TextUtils.equals(event.text(), text);
-            }
-        });
-    }
-
-    private static TextView mkTextView(final CharSequence value) {
+    private static TextView createTextView(final String value) {
         final Activity activity = Robolectric.buildActivity(Activity.class).create().get();
         final TextView text = new TextView(activity);
 
@@ -67,7 +48,7 @@ public class OperatorTextViewInputTest {
         return text;
     }
 
-    private static EditText mkEditText(final CharSequence value) {
+    private static EditText createEditText(final String value) {
         final Activity activity = Robolectric.buildActivity(Activity.class).create().get();
         final EditText text = new EditText(activity);
 
@@ -81,27 +62,27 @@ public class OperatorTextViewInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testOverloadedMethodDefaultsWithoutInitialValue() {
-        final TextView input = mkTextView("initial");
-        final Observable<OnTextChangeEvent> observable = WidgetObservable.text(input);
-        final Observer<OnTextChangeEvent> observer = mock(Observer.class);
-        final Subscription subscription = observable.subscribe(new TestObserver<OnTextChangeEvent>(observer));
+        final TextView input = createTextView("initial");
+        final Observable<TextView> observable = WidgetObservable.forText(input);
+        final Observer<TextView> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<TextView>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, never()).onNext(any(OnTextChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(any(TextView.class));
 
         input.setText("1");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "1"));
+        inOrder.verify(observer, times(1)).onNext(input);
 
         input.setText("2");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "2"));
+        inOrder.verify(observer, times(1)).onNext(input);
 
         input.setText("3");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "3"));
+        inOrder.verify(observer, times(1)).onNext(input);
 
         subscription.unsubscribe();
         input.setText("4");
-        inOrder.verify(observer, never()).onNext(any(OnTextChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(any(TextView.class));
 
         inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verify(observer, never()).onCompleted();
@@ -110,27 +91,27 @@ public class OperatorTextViewInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testWithoutInitialValue() {
-        final TextView input = mkTextView("initial");
-        final Observable<OnTextChangeEvent> observable = WidgetObservable.text(input, false);
-        final Observer<OnTextChangeEvent> observer = mock(Observer.class);
-        final Subscription subscription = observable.subscribe(new TestObserver<OnTextChangeEvent>(observer));
+        final TextView input = createTextView("initial");
+        final Observable<TextView> observable = WidgetObservable.forText(input, false);
+        final Observer<TextView> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<TextView>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, never()).onNext(any(OnTextChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(any(TextView.class));
 
         input.setText("1");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "1"));
+        inOrder.verify(observer, times(1)).onNext(input);
 
         input.setText("2");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "2"));
+        inOrder.verify(observer, times(1)).onNext(input);
 
         input.setText("3");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "3"));
+        inOrder.verify(observer, times(1)).onNext(input);
 
         subscription.unsubscribe();
         input.setText("4");
-        inOrder.verify(observer, never()).onNext(any(OnTextChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(any(TextView.class));
 
         inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verify(observer, never()).onCompleted();
@@ -139,27 +120,27 @@ public class OperatorTextViewInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testWithInitialValue() {
-        final TextView input = mkTextView("initial");
-        final Observable<OnTextChangeEvent> observable = WidgetObservable.text(input, true);
-        final Observer<OnTextChangeEvent> observer = mock(Observer.class);
-        final Subscription subscription = observable.subscribe(new TestObserver<OnTextChangeEvent>(observer));
+        final TextView input = createTextView("initial");
+        final Observable<TextView> observable = WidgetObservable.forText(input, true);
+        final Observer<TextView> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<TextView>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "initial"));
+        inOrder.verify(observer, times(1)).onNext(input);
 
-        input.setText("1");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "1"));
+        input.setText("one");
+        inOrder.verify(observer, times(1)).onNext(input);
 
-        input.setText("2");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "2"));
+        input.setText("two");
+        inOrder.verify(observer, times(1)).onNext(input);
 
-        input.setText("3");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "3"));
+        input.setText("three");
+        inOrder.verify(observer, times(1)).onNext(input);
 
         subscription.unsubscribe();
-        input.setText("4");
-        inOrder.verify(observer, never()).onNext(any(OnTextChangeEvent.class));
+        input.setText("four");
+        inOrder.verify(observer, never()).onNext(any(TextView.class));
 
         inOrder.verify(observer, never()).onError(any(Throwable.class));
         inOrder.verify(observer, never()).onCompleted();
@@ -168,35 +149,35 @@ public class OperatorTextViewInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testMultipleSubscriptions() {
-        final TextView input = mkTextView("initial");
-        final Observable<OnTextChangeEvent> observable = WidgetObservable.text(input, false);
+        final TextView input = createTextView("initial");
+        final Observable<TextView> observable = WidgetObservable.forText(input, false);
 
-        final Observer<OnTextChangeEvent> observer1 = mock(Observer.class);
-        final Observer<OnTextChangeEvent> observer2 = mock(Observer.class);
+        final Observer<TextView> observer1 = mock(Observer.class);
+        final Observer<TextView> observer2 = mock(Observer.class);
 
-        final Subscription subscription1 = observable.subscribe(new TestObserver<OnTextChangeEvent>(observer1));
-        final Subscription subscription2 = observable.subscribe(new TestObserver<OnTextChangeEvent>(observer2));
+        final Subscription subscription1 = observable.subscribe(new TestObserver<TextView>(observer1));
+        final Subscription subscription2 = observable.subscribe(new TestObserver<TextView>(observer2));
 
         final InOrder inOrder1 = inOrder(observer1);
         final InOrder inOrder2 = inOrder(observer2);
 
         input.setText("1");
-        inOrder1.verify(observer1, times(1)).onNext(mkMockedEvent(input, "1"));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(input, "1"));
+        inOrder1.verify(observer1, times(1)).onNext(input);
+        inOrder2.verify(observer2, times(1)).onNext(input);
 
         input.setText("2");
-        inOrder1.verify(observer1, times(1)).onNext(mkMockedEvent(input, "2"));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(input, "2"));
+        inOrder1.verify(observer1, times(1)).onNext(input);
+        inOrder2.verify(observer2, times(1)).onNext(input);
         subscription1.unsubscribe();
 
         input.setText("3");
-        inOrder1.verify(observer1, never()).onNext(any(OnTextChangeEvent.class));
-        inOrder2.verify(observer2, times(1)).onNext(mkMockedEvent(input, "3"));
+        inOrder1.verify(observer1, never()).onNext(any(TextView.class));
+        inOrder2.verify(observer2, times(1)).onNext(input);
         subscription2.unsubscribe();
 
         input.setText("4");
-        inOrder1.verify(observer1, never()).onNext(any(OnTextChangeEvent.class));
-        inOrder2.verify(observer2, never()).onNext(any(OnTextChangeEvent.class));
+        inOrder1.verify(observer1, never()).onNext(any(TextView.class));
+        inOrder2.verify(observer2, never()).onNext(any(TextView.class));
 
         inOrder1.verify(observer1, never()).onError(any(Throwable.class));
         inOrder2.verify(observer2, never()).onError(any(Throwable.class));
@@ -208,17 +189,46 @@ public class OperatorTextViewInputTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testTextViewSubclass() {
-        final EditText input = mkEditText("initial");
-        final Observable<OnTextChangeEvent> observable = WidgetObservable.text(input, false);
-        final Observer<OnTextChangeEvent> observer = mock(Observer.class);
-        observable.subscribe(new TestObserver<OnTextChangeEvent>(observer));
+        final EditText input = createEditText("initial");
+        final Observable<EditText> observable = WidgetObservable.forText(input, false);
+        final Observer<EditText> observer = mock(Observer.class);
+        observable.subscribe(new TestObserver<EditText>(observer));
 
         final InOrder inOrder = inOrder(observer);
 
-        inOrder.verify(observer, never()).onNext(any(OnTextChangeEvent.class));
+        inOrder.verify(observer, never()).onNext(any(EditText.class));
 
         input.setText("1");
-        inOrder.verify(observer, times(1)).onNext(mkMockedEvent(input, "1"));
+        inOrder.verify(observer, times(1)).onNext(input);
     }
-}
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLegacyStringObservableCompatibility() {
+        final EditText input = createEditText("initial");
+        final Observable<String> observable = WidgetObservable.forText(input, false)
+            .map(new Func1<EditText, String>() {
+
+                    @Override
+                    public String call(EditText view) {
+                        return view.getText().toString();
+                    }
+                });
+        final Observer<String> observer = mock(Observer.class);
+        observable.subscribe(new TestObserver<String>(observer));
+
+        final InOrder inOrder = inOrder(observer);
+
+        inOrder.verify(observer, never()).onNext(anyString());
+
+        input.setText("1");
+        inOrder.verify(observer, times(1)).onNext("1");
+
+        input.setText("2");
+        inOrder.verify(observer, times(1)).onNext("2");
+
+        input.setText("3");
+        inOrder.verify(observer, times(1)).onNext("3");
+    }
+
+}


### PR DESCRIPTION
Recent changes to UI observables (particularly, 406bf6840fff2a98316faec8702311f9322047aa) added number of POJO event classes as well as some of associated infrastructure. Some of those were really useful, but few others: click, text change and toggle (aka "input") event classes look forced, as if those were added solely to match style of similar methods. Unfortunately, as explained below, they aren't very useful and accomplish nothing, except adding redundant entities and increasing range of possible issues.

Few possible uses for event classes, that come to mind are:

1) Encapsulating state, not stored in event source itself. This is the only sensible use for event classes in Android, which is why OnItemClickEven and OnListViewScrollEvent are legitimately useful and were added for good reason. Clearly not the case for click, text change and CompoundButton toggle events.
2) Storing associated data, for example for doing `reduce` on it. None of the event classes in question (except OnSubscribeTextViewInput) contain any useful state. Click and compound button switch are self-descriptive. CharSequence, returned by `TextView.getText()`, can be mutable, and as such, is dangerous to use, unless immediately converted to string (which means, that at least one `map` call have to be done anyway).
2) Turning emission of same object into emission of multiple distinct objects. RxJava already have `timestamp` operator for this.
3) Passing those events somewhere else, possibly after serializing them. Doing so with all 3 events in question is pointless and even potentially dangerous. All of them contain little besides strong reference to event source, which makes them potential source of memory leaks, and makes it harder to write Rx plugins, detecting those.

This merge request adds back Observables with tests and corresponding static methods, emitting plain View, TextView and Boolean objects. It also deprecates event-based methods. While we are at it, I have also renamed "input" to "toggle" as original naming choice was just plain bad.