### PR TITLE
Fixed broken builds in IntelliJ

### DIFF
--- a/rxandroid-framework/build.gradle
+++ b/rxandroid-framework/build.gradle
@@ -1,26 +1,5 @@
-buildscript {
-    repositories { jcenter() }
-    dependencies {
-        classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:1.12.+'
-        classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:1.12.+'
-    }
-}
-
-apply plugin: 'rxjava-project'
-apply plugin: 'provided-base'
-
-dependencies {
-    compile "io.reactivex:rxjava:$rxJavaVersion"
-    provided 'com.google.android:android:4.0.1.2'
-    provided 'com.google.android:support-v4:r7'
-
-    // testing
-    testCompile 'junit:junit-dep:4.11'
-    testCompile 'org.mockito:mockito-core:1.10.8'
-    testCompile('org.robolectric:robolectric:2.4') {
-        exclude group: 'com.android.support'
-    }
-}
+// Multi-module modules aren't really supported
+version = rootProject.version
 
 test {
     testLogging {
@@ -28,4 +7,8 @@ test {
         events "started"
         displayGranularity 2
     }
+}
+
+dependencies {
+    compile(project(":rxandroid"))
 }


### PR DESCRIPTION
To be honest, not even sure how it was building command-line, but now
it's no longer double-including all its funky dependencies.

Looks like things got wonky since the creation of the rxandroid-framework directory.
