### PR TITLE
Don't throw exception, instead user should find out at compile time that they're passing the wrong argument

### DIFF
--- a/rxandroid/src/main/java/rx/android/app/AppObservable.java
+++ b/rxandroid/src/main/java/rx/android/app/AppObservable.java
@@ -110,9 +110,7 @@ public final class AppObservable {
      * @param source   the source sequence
      */
     public static <T> Observable<T> bindFragment(Fragment fragment, Observable<T> source) {
-        Assertions.assertUiThread();
-        final Observable<T> o = source.observeOn(mainThread());
-        return o.lift(new OperatorConditionalBinding<T, Fragment>(fragment, FRAGMENT_VALIDATOR));
+        return bindFragmentInternal(fragment, source);
     }
 
     /**
@@ -130,8 +128,6 @@ public final class AppObservable {
      * @param source   the source sequence
      */
     public static <T> Observable<T> bindFragment(android.support.v4.app.Fragment fragment, Observable<T> source) {
-        Assertions.assertUiThread();
-        final Observable<T> o = source.observeOn(mainThread());
-        return o.lift(new OperatorConditionalBinding<T, android.support.v4.app.Fragment>(fragment, FRAGMENTV4_VALIDATOR));
+        return bindFragmentInternal(fragment, source);
     }
 }


### PR DESCRIPTION
Inside AppObservable, you have a method `bindFragment(Object,Observable<T>)`. Instead of accepting an `Object` parameter, you should have two methods, one accepting a `Fragment` and the other accepting a `android.support.v4.app.Fragment`.