### PR TITLE
add bindLifecycle rxactivity/rxfragment instance method

### DIFF
--- a/rxandroid-framework/src/main/java/rx/android/app/RxActivity.java
+++ b/rxandroid-framework/src/main/java/rx/android/app/RxActivity.java
@@ -17,6 +17,7 @@ package rx.android.app;
 import android.os.Bundle;
 import rx.Observable;
 import rx.android.lifecycle.LifecycleEvent;
+import rx.android.lifecycle.LifecycleObservable;
 import rx.subjects.BehaviorSubject;
 
 /**
@@ -28,6 +29,10 @@ public class RxActivity extends android.app.Activity {
 
     public Observable<LifecycleEvent> lifecycle() {
         return lifecycleSubject.asObservable();
+    }
+
+    public <T> Observable<T> bindLifecycle(Observable<T> source) {
+        return LifecycleObservable.bindActivityLifecycle(lifecycle(), source);
     }
 
     @Override

--- a/rxandroid-framework/src/main/java/rx/android/app/RxDialogFragment.java
+++ b/rxandroid-framework/src/main/java/rx/android/app/RxDialogFragment.java
@@ -18,6 +18,7 @@ import android.os.Bundle;
 import android.view.View;
 import rx.Observable;
 import rx.android.lifecycle.LifecycleEvent;
+import rx.android.lifecycle.LifecycleObservable;
 import rx.subjects.BehaviorSubject;
 
 /**
@@ -29,6 +30,10 @@ public class RxDialogFragment extends android.app.DialogFragment {
 
     public Observable<LifecycleEvent> lifecycle() {
         return lifecycleSubject.asObservable();
+    }
+
+    public <T> Observable<T> bindLifecycle(Observable<T> source) {
+        return LifecycleObservable.bindFragmentLifecycle(lifecycle(), source);
     }
 
     @Override

--- a/rxandroid-framework/src/main/java/rx/android/app/RxFragment.java
+++ b/rxandroid-framework/src/main/java/rx/android/app/RxFragment.java
@@ -18,6 +18,7 @@ import android.os.Bundle;
 import android.view.View;
 import rx.Observable;
 import rx.android.lifecycle.LifecycleEvent;
+import rx.android.lifecycle.LifecycleObservable;
 import rx.subjects.BehaviorSubject;
 
 /**
@@ -29,6 +30,10 @@ public class RxFragment extends android.app.Fragment {
 
     public Observable<LifecycleEvent> lifecycle() {
         return lifecycleSubject.asObservable();
+    }
+
+    public <T> Observable<T> bindLifecycle(Observable<T> source) {
+        return LifecycleObservable.bindFragmentLifecycle(lifecycle(), source);
     }
 
     @Override

--- a/rxandroid-framework/src/main/java/rx/android/app/support/RxDialogFragment.java
+++ b/rxandroid-framework/src/main/java/rx/android/app/support/RxDialogFragment.java
@@ -18,6 +18,7 @@ import android.os.Bundle;
 import android.view.View;
 import rx.Observable;
 import rx.android.lifecycle.LifecycleEvent;
+import rx.android.lifecycle.LifecycleObservable;
 import rx.subjects.BehaviorSubject;
 
 /**
@@ -29,6 +30,10 @@ public class RxDialogFragment extends android.support.v4.app.DialogFragment {
 
     public Observable<LifecycleEvent> lifecycle() {
         return lifecycleSubject.asObservable();
+    }
+
+    public <T> Observable<T> bindLifecycle(Observable<T> source) {
+        return LifecycleObservable.bindFragmentLifecycle(lifecycle(), source);
     }
 
     @Override

--- a/rxandroid-framework/src/main/java/rx/android/app/support/RxFragment.java
+++ b/rxandroid-framework/src/main/java/rx/android/app/support/RxFragment.java
@@ -18,6 +18,7 @@ import android.os.Bundle;
 import android.view.View;
 import rx.Observable;
 import rx.android.lifecycle.LifecycleEvent;
+import rx.android.lifecycle.LifecycleObservable;
 import rx.subjects.BehaviorSubject;
 
 /**
@@ -29,6 +30,10 @@ public class RxFragment extends android.support.v4.app.Fragment {
 
     public Observable<LifecycleEvent> lifecycle() {
         return lifecycleSubject.asObservable();
+    }
+
+    public <T> Observable<T> bindLifecycle(Observable<T> source) {
+        return LifecycleObservable.bindFragmentLifecycle(lifecycle(), source);
     }
 
     @Override

--- a/rxandroid-framework/src/main/java/rx/android/app/support/RxFragmentActivity.java
+++ b/rxandroid-framework/src/main/java/rx/android/app/support/RxFragmentActivity.java
@@ -17,6 +17,7 @@ package rx.android.app.support;
 import android.os.Bundle;
 import rx.Observable;
 import rx.android.lifecycle.LifecycleEvent;
+import rx.android.lifecycle.LifecycleObservable;
 import rx.subjects.BehaviorSubject;
 
 /**
@@ -28,6 +29,10 @@ public class RxFragmentActivity extends android.support.v4.app.FragmentActivity 
 
     public Observable<LifecycleEvent> lifecycle() {
         return lifecycleSubject.asObservable();
+    }
+
+    public <T> Observable<T> bindLifecycle(Observable<T> source) {
+        return LifecycleObservable.bindActivityLifecycle(lifecycle(), source);
     }
 
     @Override


### PR DESCRIPTION
`bindLifecycle(sourceObservable)` is just a alias for corresponding static method `LifecycleObservable.bindFragmentLifecycle(source)`/`LifecycleObservable.bindActivityLifecycle(source)`

Main purpose is to decrease boilerplate code while binding observable to lifecyle
Also, if method references are supported, this method can be used directly in `compose` operator: 
```java
source.compose(this::bindLifecycle)
```

Another issue it can prevent is copy/paste of code between fragment/activity which include `bindLifecycle`:

```java
LifecycleObservable.bindFragmentLifecycle(lifecycle(), source)
```
if this code was copied while refactoring to activity, it will compile but can lead to wrong behavior.
While:
```java
bindLifecycle(source)
```
will work as expected as proper bind strategy is specified in rxactivity/rxfragment 
