### PR TITLE
Add helper contentObservable for contentObserver

### DIFF
--- a/rxandroid/src/main/java/rx/android/content/ContentObservable.java
+++ b/rxandroid/src/main/java/rx/android/content/ContentObservable.java
@@ -13,11 +13,13 @@
  */
 package rx.android.content;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.database.Cursor;
+import android.net.Uri;
 import android.os.Handler;
 
 import rx.Observable;
@@ -25,6 +27,35 @@ import rx.Observable;
 public final class ContentObservable {
     private ContentObservable() {
         throw new AssertionError("No instances");
+    }
+
+    /**
+     * Create Observable that wraps ContentObserver and emits received changed Uris.
+     *
+     * @param contentResolver
+     * @param uri             The URI to watch for changes.  This can be a specific row URI,
+     *                        or a base URI for a whole class of content.
+     * @return
+     */
+    public static Observable<Uri> fromContentObserver(ContentResolver contentResolver, Uri uri) {
+        return Observable.create(new OnSubscribeContentObserverRegister(contentResolver, uri,
+            null));
+    }
+
+    /**
+     * Create Observable that wraps ContentObserver and emits received changed Uris.
+     *
+     * @param contentResolver
+     * @param uri              The URI to watch for changes.  This can be a specific row
+     *                         URI, or a base URI for a whole class of content.
+     * @param schedulerHandler The handler to run {@link android.database
+     *                         .ContentObserver#onChange(boolean)} on, or null if none.
+     * @return
+     */
+    public static Observable<Uri> fromContentObserver(ContentResolver contentResolver, Uri uri,
+        Handler schedulerHandler) {
+        return Observable.create(new OnSubscribeContentObserverRegister(contentResolver, uri,
+            schedulerHandler));
     }
 
     /**

--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeContentObserverRegister.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeContentObserverRegister.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.content;
+
+import android.content.ContentResolver;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Handler;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+class OnSubscribeContentObserverRegister implements Observable.OnSubscribe<Uri> {
+
+    private final ContentResolver contentResolver;
+    private final Uri uri;
+    private final Handler schedulerHandler;
+
+    public OnSubscribeContentObserverRegister(ContentResolver contentResolver, Uri uri,
+        Handler schedulerHandler) {
+        this.contentResolver = contentResolver;
+        this.uri = uri;
+        this.schedulerHandler = schedulerHandler;
+    }
+
+    @Override
+    public void call(final Subscriber<? super Uri> subscriber) {
+        final ContentObserver contentObserver = new ContentObserver(schedulerHandler) {
+            @Override public void onChange(boolean selfChange) {
+                subscriber.onNext(uri);
+            }
+
+            /*@Override*/
+            public void onChange(boolean selfChange, Uri uri) {
+                subscriber.onNext(uri);
+            }
+        };
+
+        final Subscription subscription = Subscriptions.create(new Action0() {
+            @Override
+            public void call() {
+                contentResolver.unregisterContentObserver(contentObserver);
+            }
+        });
+
+        subscriber.add(subscription);
+        contentResolver.registerContentObserver(uri, true, contentObserver);
+    }
+
+}

--- a/rxandroid/src/test/java/rx/android/content/OperatorContentObserverRegisterTest.java
+++ b/rxandroid/src/test/java/rx/android/content/OperatorContentObserverRegisterTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.content;
+
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.net.Uri;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.robolectric.RobolectricTestRunner;
+
+import rx.Observable;
+import rx.Observer;
+import rx.Subscription;
+import rx.observers.TestObserver;
+
+import static android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@RunWith(RobolectricTestRunner.class)
+public class OperatorContentObserverRegisterTest {
+
+    private ContentResolver contentResolver;
+
+    @Before
+    public void setUp() throws Exception {
+        this.contentResolver = new Activity().getContentResolver();
+    }
+
+    @Test
+    public void testUriChanges() {
+        Observable<Uri> observable
+            = ContentObservable.fromContentObserver(contentResolver, EXTERNAL_CONTENT_URI);
+        final Observer<Uri> observer = mock(Observer.class);
+        final Subscription subscription = observable.subscribe(new TestObserver<Uri>(observer));
+
+        final InOrder inOrder = inOrder(observer);
+
+        inOrder.verify(observer, never()).onNext(any(Uri.class));
+
+        contentResolver.notifyChange(EXTERNAL_CONTENT_URI, null);
+        inOrder.verify(observer, times(1)).onNext(EXTERNAL_CONTENT_URI);
+
+        contentResolver.notifyChange(EXTERNAL_CONTENT_URI, null);
+        inOrder.verify(observer, times(1)).onNext(EXTERNAL_CONTENT_URI);
+
+        subscription.unsubscribe();
+        contentResolver.notifyChange(EXTERNAL_CONTENT_URI, null);
+        inOrder.verify(observer, never()).onNext(any(Uri.class));
+
+        inOrder.verify(observer, never()).onError(any(Throwable.class));
+        inOrder.verify(observer, never()).onCompleted();
+    }
+
+}


### PR DESCRIPTION
Add an helper function 
```
ContentObservable.fromContentObserver(contentResolver, watchUri, schedulerHandler)
```
that makes the ContentObserver as an Observable