### PR TITLE
Add OnSubscribeQuery (a variation of OnSubscribeCursor)

### DIFF
--- a/rxandroid/src/main/java/rx/android/content/ContentObservable.java
+++ b/rxandroid/src/main/java/rx/android/content/ContentObservable.java
@@ -13,11 +13,13 @@
  */
 package rx.android.content;
 
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.database.Cursor;
+import android.net.Uri;
 import android.os.Handler;
 
 import rx.Observable;
@@ -77,4 +79,35 @@ public final class ContentObservable {
     public static Observable<Cursor> fromCursor(final Cursor cursor) {
         return Observable.create(new OnSubscribeCursor(cursor));
     }
+
+    /**
+     * Create Observable that makes a {@link android.content.ContentResolver} query and emits the
+     * resulting {@link android.database.Cursor} for each available position.
+     *
+     * @param contentResolver
+     * @param uri             The URI, using the content:// scheme, for the content to retrieve.
+     * @param projection      A list of which columns to return.  Passing null will return all
+     *                        columns, which is discouraged to prevent reading data from storage
+     *                        that
+     *                        isn't going to be used.
+     * @param selection       A filter declaring which rows to return,
+     *                        formatted as an SQL WHERE clause
+     *                        (excluding the WHERE itself).  Passing null will return all rows
+     *                        for the
+     *                        given URI.
+     * @param selectionArgs   You may include ?s in selection, which will be replaced by the values
+     *                        from selectionArgs, in the order that they appear in the selection.
+     *                        The values will be bound as Strings.
+     * @param orderBy         How to order the rows, formatted as an SQL ORDER BY clause
+     *                        (excluding the
+     *                        ORDER BY itself).  Passing null will use the default sort order,
+     *                        which may be unordered.
+     * @return
+     */
+    public static Observable<Cursor> fromQuery(ContentResolver contentResolver, Uri uri,
+        String[] projection, String selection, String[] selectionArgs, String orderBy) {
+        return Observable.create(new OnSubscribeQuery(contentResolver, uri, projection,
+            selection, selectionArgs, orderBy));
+    }
+
 }

--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeQuery.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeQuery.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.content;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * A variation of {@link rx.android.content.OnSubscribeCursor} that makes a query in addition to
+ * emitting a {@link android.database.Cursor} for every available position.
+ */
+final class OnSubscribeQuery implements Observable.OnSubscribe<Cursor> {
+
+    private final ContentResolver contentResolver;
+    private final Uri uri;
+    private final String[] projection;
+    private final String selection;
+    private final String[] selectionArgs;
+    private final String orderBy;
+
+    OnSubscribeQuery(ContentResolver contentResolver, Uri uri, String[] projection,
+        String selection, String[] selectionArgs, String orderBy) {
+        this.contentResolver = contentResolver;
+        this.uri = uri;
+        this.projection = projection;
+        this.selection = selection;
+        this.selectionArgs = selectionArgs;
+        this.orderBy = orderBy;
+    }
+
+    @Override
+    public void call(final Subscriber<? super Cursor> subscriber) {
+        Cursor cursor = null;
+        try {
+            cursor = contentResolver.query(uri, projection, selection, selectionArgs, orderBy);
+            while (!subscriber.isUnsubscribed() && cursor.moveToNext()) {
+                subscriber.onNext(cursor);
+            }
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onCompleted();
+            }
+        } catch (Throwable e) {
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onError(e);
+            }
+        } finally {
+            if (cursor != null && !cursor.isClosed()) {
+                cursor.close();
+            }
+        }
+    }
+
+}

--- a/rxandroid/src/test/java/rx/android/content/OnSubscribeQueryTest.java
+++ b/rxandroid/src/test/java/rx/android/content/OnSubscribeQueryTest.java
@@ -1,0 +1,191 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.content;
+
+import android.app.Activity;
+import android.content.ContentProvider;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowContentResolver;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.observers.TestSubscriber;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static rx.android.content.ContentObservable.fromQuery;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class OnSubscribeQueryTest {
+
+    private static final String AUTHORITY = "rx.android";
+    private static final Uri URI = Uri.parse("content://" + AUTHORITY + "/path");
+
+    private ContentResolver contentResolver;
+    private TestContentProvider provider;
+
+    @Before
+    public void setUp() throws Exception {
+        this.contentResolver = new Activity().getContentResolver();
+        this.provider = new TestContentProvider();
+        ShadowContentResolver.registerProvider(AUTHORITY, provider);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ShadowContentResolver.registerProvider(AUTHORITY, null);
+    }
+
+    @Test
+    public void givenCursorWhenFromQueryInvokedThenObservableCallsOnNextWhileHasNext() {
+        final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
+        final Cursor cursor = mock(Cursor.class);
+        provider.cursor = cursor;
+
+        when(cursor.isAfterLast()).thenReturn(false, false, true);
+        when(cursor.moveToNext()).thenReturn(true, true, false);
+        when(cursor.getCount()).thenReturn(2);
+
+        Observable<Cursor> observable = fromQuery(contentResolver, URI, null, null, null, null);
+        observable.subscribe(subscriber);
+
+        verify(subscriber, times(2)).onNext(cursor);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber).onCompleted();
+    }
+
+    @Test
+    public void givenEmptyCursorWhenFromQueryInvokedThenObservableCompletesWithoutCallingOnNext() {
+        final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
+        final Cursor cursor = mock(Cursor.class);
+        provider.cursor = cursor;
+
+        Observable<Cursor> observable = fromQuery(contentResolver, URI, null, null, null, null);
+        observable.subscribe(subscriber);
+
+        verify(subscriber, never()).onNext(cursor);
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber).onCompleted();
+    }
+
+    @Test
+    public void givenCursorWhenFromQueryCalledThenEmitsAndClosesCursorAfterCompletion() {
+        final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
+        final Cursor cursor = mock(Cursor.class);
+        provider.cursor = cursor;
+
+        when(cursor.isAfterLast()).thenReturn(false, true);
+        when(cursor.moveToNext()).thenReturn(true, false);
+        when(cursor.getCount()).thenReturn(1);
+
+        Observable<Cursor> observable = fromQuery(contentResolver, URI, null, null, null, null);
+        observable.subscribe(subscriber);
+
+        verify(subscriber, never()).onError(any(Throwable.class));
+        verify(subscriber).onNext(cursor);
+        verify(cursor).close();
+        verify(subscriber).onCompleted();
+    }
+
+    @Test
+    public void givenCursorWhenFromQueryCalledThenEmitsAndClosesCursorAfterSubscriberError() {
+        final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
+        final Cursor cursor = mock(Cursor.class);
+        provider.cursor = cursor;
+        final RuntimeException throwable = mock(RuntimeException.class);
+        doThrow(throwable).when(subscriber).onNext(cursor);
+
+        when(cursor.isAfterLast()).thenReturn(false, true);
+        when(cursor.moveToNext()).thenReturn(true, false);
+        when(cursor.getCount()).thenReturn(1);
+
+        Observable<Cursor> observable = fromQuery(contentResolver, URI, null, null, null, null);
+        observable.subscribe(subscriber);
+
+        verify(subscriber, never()).onCompleted();
+        verify(subscriber).onNext(cursor);
+        verify(subscriber).onError(throwable);
+        verify(cursor).close();
+    }
+
+    @Test
+    public void givenCursorWhenFromQueryCalledThenEmitsAndClosesCursorAfterObservableError() {
+        final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
+        final Cursor cursor = mock(Cursor.class);
+        provider.cursor = cursor;
+        final RuntimeException throwable = mock(RuntimeException.class);
+
+        when(cursor.isAfterLast()).thenReturn(false, false, true);
+        when(cursor.moveToNext()).thenReturn(true).thenThrow(throwable);
+        when(cursor.getCount()).thenReturn(2);
+
+        Observable<Cursor> observable = fromQuery(contentResolver, URI, null, null, null, null);
+        observable.subscribe(subscriber);
+
+        verify(subscriber, never()).onCompleted();
+        verify(subscriber).onNext(cursor);
+        verify(subscriber).onError(throwable);
+        verify(cursor).close();
+    }
+
+    static class TestContentProvider extends ContentProvider {
+        private Cursor cursor;
+
+        @Override public boolean onCreate() {
+            return false;
+        }
+
+        @Override
+        public Cursor query(Uri uri, String[] projection, String selection,
+            String[] selectionArgs, String sortOrder) {
+            return cursor;
+        }
+
+        @Override public String getType(Uri uri) {
+            return null;
+        }
+
+        @Override public Uri insert(Uri uri, ContentValues values) {
+            return null;
+        }
+
+        @Override public int delete(Uri uri, String selection, String[] selectionArgs) {
+            return 0;
+        }
+
+        @Override
+        public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+            return 0;
+        }
+    }
+
+}


### PR DESCRIPTION
`ContentObservable.fromCursor()` is useful when we get hold of a `Cursor` instance from some asynchronous query already.  However, in some cases it might be useful to make the query asynchronously in the same observable creation function.

This pull request adds another herlper method `ContentObservable.fromQuery()` which takes as input parameters much like those of `AsyncQueryHandler.startQuery()` and returns an `Observable` emitting Cursor resulting from the query.