### PR TITLE
invoke onError when possible

### DIFF
--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeCursor.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeCursor.java
@@ -35,12 +35,18 @@ final class OnSubscribeCursor implements Observable.OnSubscribe<Cursor> {
             while (!subscriber.isUnsubscribed() && cursor.moveToNext()) {
                 subscriber.onNext(cursor);
             }
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onCompleted();
+            }
+        } catch (Throwable e) {
+            if (!subscriber.isUnsubscribed()) {
+                subscriber.onError(e);
+            }
         } finally {
             if (!cursor.isClosed()) {
                 cursor.close();
             }
         }
-        subscriber.onCompleted();
     }
 
 }

--- a/rxandroid/src/test/java/rx/android/content/ContentObservableTest.java
+++ b/rxandroid/src/test/java/rx/android/content/ContentObservableTest.java
@@ -85,7 +85,7 @@ public class ContentObservableTest {
     }
 
     @Test
-    public void givenCursorWhenFromCursorCalledThenEmitsAndClosesCursorAfterError() {
+    public void givenCursorWhenFromCursorCalledThenEmitsAndClosesCursorAfterSubscriberError() {
         final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
         final Cursor cursor = mock(Cursor.class);
         final RuntimeException throwable = mock(RuntimeException.class);
@@ -103,4 +103,24 @@ public class ContentObservableTest {
         verify(subscriber).onError(throwable);
         verify(cursor).close();
     }
+
+    @Test
+    public void givenCursorWhenFromCursorCalledThenEmitsAndClosesCursorAfterObservableError() {
+        final Subscriber<Cursor> subscriber = spy(new TestSubscriber<Cursor>());
+        final Cursor cursor = mock(Cursor.class);
+        final RuntimeException throwable = mock(RuntimeException.class);
+
+        when(cursor.isAfterLast()).thenReturn(false, false, true);
+        when(cursor.moveToNext()).thenReturn(true).thenThrow(throwable);
+        when(cursor.getCount()).thenReturn(2);
+
+        Observable<Cursor> observable = ContentObservable.fromCursor(cursor);
+        observable.subscribe(subscriber);
+
+        verify(subscriber, never()).onCompleted();
+        verify(subscriber).onNext(cursor);
+        verify(subscriber).onError(throwable);
+        verify(cursor).close();
+    }
+
 }


### PR DESCRIPTION
Allow `onError()` to be invoked when the observable returned from `ContentObservable.fromCursor()` encounters an exception.