### PR TITLE
Fixed concurrent modifications in UI components when subscribing taken events

### DIFF
--- a/rxandroid/src/main/java/rx/android/view/OnSubscribeViewClick.java
+++ b/rxandroid/src/main/java/rx/android/view/OnSubscribeViewClick.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 final class OnSubscribeViewClick implements Observable.OnSubscribe<OnClickEvent> {
     private final boolean emitInitialValue;
@@ -63,7 +64,7 @@ final class OnSubscribeViewClick implements Observable.OnSubscribe<OnClickEvent>
     }
 
     private static class CompositeOnClickListener implements View.OnClickListener {
-        private final List<View.OnClickListener> listeners = new ArrayList<View.OnClickListener>();
+        private final List<View.OnClickListener> listeners = new CopyOnWriteArrayList<View.OnClickListener>();
 
         public boolean addOnClickListener(final View.OnClickListener listener) {
             return listeners.add(listener);

--- a/rxandroid/src/main/java/rx/android/widget/OnSubscribeAdapterViewOnItemClick.java
+++ b/rxandroid/src/main/java/rx/android/widget/OnSubscribeAdapterViewOnItemClick.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -61,7 +62,7 @@ class OnSubscribeAdapterViewOnItemClick implements Observable.OnSubscribe<OnItem
     }
 
     private static class CompositeOnClickListener implements AbsListView.OnItemClickListener {
-        private final List<AbsListView.OnItemClickListener> listeners = new ArrayList<AbsListView.OnItemClickListener>();
+        private final List<AbsListView.OnItemClickListener> listeners = new CopyOnWriteArrayList<AbsListView.OnItemClickListener>();
 
         public boolean addOnClickListener(final AbsListView.OnItemClickListener listener) {
             return listeners.add(listener);

--- a/rxandroid/src/main/java/rx/android/widget/OnSubscribeCompoundButtonInput.java
+++ b/rxandroid/src/main/java/rx/android/widget/OnSubscribeCompoundButtonInput.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 class OnSubscribeCompoundButtonInput implements Observable.OnSubscribe<OnCheckedChangeEvent> {
     private final boolean emitInitialValue;
@@ -65,7 +66,7 @@ class OnSubscribeCompoundButtonInput implements Observable.OnSubscribe<OnChecked
     }
 
     private static class CompositeOnCheckedChangeListener implements CompoundButton.OnCheckedChangeListener {
-        private final List<CompoundButton.OnCheckedChangeListener> listeners = new ArrayList<CompoundButton.OnCheckedChangeListener>();
+        private final List<CompoundButton.OnCheckedChangeListener> listeners = new CopyOnWriteArrayList<CompoundButton.OnCheckedChangeListener>();
 
         public boolean addOnCheckedChangeListener(final CompoundButton.OnCheckedChangeListener listener) {
             return listeners.add(listener);

--- a/rxandroid/src/main/java/rx/android/widget/OnSubscribeListViewScroll.java
+++ b/rxandroid/src/main/java/rx/android/widget/OnSubscribeListViewScroll.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 class OnSubscribeListViewScroll implements Observable.OnSubscribe<OnListViewScrollEvent> {
 
@@ -67,7 +68,7 @@ class OnSubscribeListViewScroll implements Observable.OnSubscribe<OnListViewScro
 
     private static class CompositeOnScrollListener implements AbsListView.OnScrollListener {
 
-        private final List<AbsListView.OnScrollListener> listeners = new ArrayList<AbsListView.OnScrollListener>();
+        private final List<AbsListView.OnScrollListener> listeners = new CopyOnWriteArrayList<AbsListView.OnScrollListener>();
 
         public boolean addOnScrollListener(final AbsListView.OnScrollListener listener) {
             return listeners.add(listener);


### PR DESCRIPTION
This fixes ConcurrentModificationException which is thrown by Observables that invoked Observable#take(int).

Relevant issue is #158 .