### PR TITLE
[ContentObservable] Added loadCursor and registerContentObserver

### DIFF
--- a/rxandroid/src/main/java/rx/android/content/ContentObservable.java
+++ b/rxandroid/src/main/java/rx/android/content/ContentObservable.java
@@ -79,10 +79,29 @@ public final class ContentObservable {
         return Observable.create(new OnSubscribeCursor(cursor));
     }
 
+  /**
+   * Create Observable that emits cursor when it's loaded in background.
+   *
+   * @param context
+   * @param uri
+   * @param projection
+   * @param selection
+   * @param selectionArgs
+   * @param sortOrder
+   * @return
+   */
     public static Observable<Cursor> loadCursor(Context context, Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
         return Observable.create(new OnSubscribeLoadCursor(context, uri, projection, selection, selectionArgs, sortOrder));
     }
 
+  /**
+   * Create Observable that emits that can registerContentObserver
+   *
+   * @param context
+   * @param uri
+   * @param notifyForDescendents
+   * @return
+   */
     public static Observable<Boolean> registerContentObserver(Context context, Uri uri, boolean notifyForDescendents) {
         return Observable.create(new OnSubscribeRegisterContentObserver(context, uri, notifyForDescendents));
     }

--- a/rxandroid/src/main/java/rx/android/content/ContentObservable.java
+++ b/rxandroid/src/main/java/rx/android/content/ContentObservable.java
@@ -18,6 +18,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.database.Cursor;
+import android.net.Uri;
 import android.os.Handler;
 
 import rx.Observable;
@@ -77,4 +78,13 @@ public final class ContentObservable {
     public static Observable<Cursor> fromCursor(final Cursor cursor) {
         return Observable.create(new OnSubscribeCursor(cursor));
     }
+
+    public static Observable<Cursor> loadCursor(Context context, Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return Observable.create(new OnSubscribeLoadCursor(context, uri, projection, selection, selectionArgs, sortOrder));
+    }
+
+    public static Observable<Boolean> registerContentObserver(Context context, Uri uri, boolean notifyForDescendents) {
+        return Observable.create(new OnSubscribeRegisterContentObserver(context, uri, notifyForDescendents));
+    }
+
 }

--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeLoadCursor.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeLoadCursor.java
@@ -1,11 +1,9 @@
-/*
- * Copyright 2015 "Henry Tao <hi@henrytao.me>"
- *
+/**
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeLoadCursor.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeLoadCursor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 "Henry Tao <hi@henrytao.me>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.android.content;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * Created by henrytao on 6/9/15.
+ */
+public class OnSubscribeLoadCursor implements Observable.OnSubscribe<Cursor> {
+
+  private final Context mContext;
+
+  private final Uri mUri;
+
+  private String[] mProjection;
+
+  private String mSelection;
+
+  private String[] mSelectionArgs;
+
+  private String mSortOrder;
+
+  public OnSubscribeLoadCursor(Context context, Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+    mContext = context;
+    mUri = uri;
+    mProjection = projection;
+    mSelection = selection;
+    mSelectionArgs = selectionArgs;
+    mSortOrder = sortOrder;
+  }
+
+  @Override
+  public void call(Subscriber<? super Cursor> subscriber) {
+    final Cursor cursor = mContext.getContentResolver().query(mUri, mProjection, mSelection, mSelectionArgs, mSortOrder);
+    final Subscription subscription = Subscriptions.create(new Action0() {
+      @Override
+      public void call() {
+        if (cursor != null) {
+          cursor.close();
+        }
+      }
+    });
+    subscriber.add(subscription);
+    subscriber.onNext(cursor);
+  }
+
+}

--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeRegisterContentObserver.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeRegisterContentObserver.java
@@ -1,11 +1,9 @@
-/*
- * Copyright 2015 "Henry Tao <hi@henrytao.me>"
- *
+/**
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/rxandroid/src/main/java/rx/android/content/OnSubscribeRegisterContentObserver.java
+++ b/rxandroid/src/main/java/rx/android/content/OnSubscribeRegisterContentObserver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 "Henry Tao <hi@henrytao.me>"
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rx.android.content;
+
+import android.content.Context;
+import android.database.ContentObserver;
+import android.net.Uri;
+
+import rx.Observable;
+import rx.Subscriber;
+import rx.Subscription;
+import rx.functions.Action0;
+import rx.subscriptions.Subscriptions;
+
+/**
+ * Created by henrytao on 6/9/15.
+ */
+public class OnSubscribeRegisterContentObserver implements Observable.OnSubscribe<Boolean> {
+
+  private final Context mContext;
+
+  private final Uri mUri;
+
+  private final boolean mNotifyForDescendents;
+
+  public OnSubscribeRegisterContentObserver(Context context, Uri uri, boolean notifyForDescendents) {
+    mContext = context;
+    mUri = uri;
+    mNotifyForDescendents = notifyForDescendents;
+  }
+
+  @Override
+  public void call(final Subscriber<? super Boolean> subscriber) {
+    final ContentObserver observer = new ContentObserver(null) {
+
+      @Override
+      public void onChange(boolean selfChange) {
+        subscriber.onNext(selfChange);
+      }
+    };
+
+    final Subscription subscription = Subscriptions.create(new Action0() {
+      @Override
+      public void call() {
+        if (observer != null) {
+          mContext.getContentResolver().unregisterContentObserver(observer);
+        }
+      }
+    });
+    subscriber.add(subscription);
+    mContext.getContentResolver().registerContentObserver(mUri, mNotifyForDescendents, observer);
+  }
+
+}


### PR DESCRIPTION
Hi all, I think it's quite interesting and useful to have these two methods when you want to handle cursor outside `loaderManager` lifecycle. I will write more test cases then. 

Current code
```
public void loadCursorInBackground(Context context, Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder, final AsyncCallback<Cursor> callback) {
    start(callback);
    execute(new Runnable() {
      @Override
      public void run() {
        try {
          Cursor cursor = mContext.getContentResolver().query(uri, projection, selection, selectionArgs, sortOrder);
          success(callback, cursor);
        } catch (Exception e) {
          failure(callback, e);
        }
      }
    });
}
```

Rx code
```
ContentObservable.loadCursor(getActivity(), uri, projection, selection, selectionArgs, sortOrder)
        .subscribeOn(Schedulers.io())
        .observeOn(AndroidSchedulers.mainThread())
        .subscribe(cursor -> onCursorLoaded(cursor))
```

Current code
```
ContentResolver contentResolver = activity.getContentResolver();
contentResolver.registerContentObserver(ChatMessageProvider.CONTENT_URI, false, mChatRoomContentObserver);
```

Rx code
```
ContentObservable.registerContentObserver(getActivity(), ChatMessageProvider.CONTENT_URI, false)
          .subscribeOn(Schedulers.io())
          .subscribe(selfChange -> loadChatRoomInBackground())
```