### PR TITLE
Use Android build system, generate AARs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,40 +1,17 @@
 buildscript {
-  repositories { jcenter() }
+  repositories {
+    mavenCentral()
+  }
   dependencies {
-    classpath 'com.netflix.nebula:gradle-rxjava-project-plugin:2.+'
-    classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:2.+'
+    classpath 'com.android.tools.build:gradle:1.2.3'
   }
 }
 
-apply plugin: 'rxjava-project'
-bintrayUpload.enabled = false
-
-def libraryModules = subprojects.findAll { it.name != 'sample-app' }
-configure(libraryModules) {
-  apply plugin: 'rxjava-project'
-  apply plugin: 'java'
-  apply plugin: 'provided-base'
-
-  dependencies {
-    compile "io.reactivex:rxjava:$rxJavaVersion"
-    provided 'com.google.android:android:4.0.1.2'
-    provided 'com.google.android:support-v4:r7'
-
-    // testing
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile('org.robolectric:robolectric:2.4') {
-      exclude group: 'com.android.support'
-    }
-  }
+ext {
+  minSdkVersion = 15
+  compileSdkVersion = 22
+  targetSdkVersion = compileSdkVersion
+  buildToolsVersion = '22.0.1'
 }
 
-// support for snapshot/final releases with the various branches RxJava uses
-nebulaRelease {
-    addReleaseBranchPattern(/\d+\.\d+\.\d+/)
-    addReleaseBranchPattern('HEAD')
-}
-
-if (project.hasProperty('release.useLastTag')) {
-    tasks.prepare.enabled = false
-}
+apply plugin: 'android-reporting'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-rxJavaVersion=1.0.+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 13 00:15:28 PST 2014
+#Tue Jun 30 13:03:06 CDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -1,10 +1,23 @@
-// Multi-module modules aren't really supported
-version = rootProject.version
+apply plugin: 'com.android.library'
 
-test {
-    testLogging {
-        exceptionFormat "full"
-        events "started"
-        displayGranularity 2
-    }
+android {
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  buildToolsVersion rootProject.ext.buildToolsVersion
+
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+  }
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile 'io.reactivex:rxjava:1.0.12'
+
+  testCompile 'junit:junit:4.12'
+  testCompile 'org.mockito:mockito-core:1.10.19'
+  testCompile 'org.robolectric:robolectric:2.4'
 }

--- a/rxandroid/src/main/AndroidManifest.xml
+++ b/rxandroid/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<manifest package="rx.android" />

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -1,28 +1,21 @@
-buildscript {
-    repositories { jcenter() }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
-    }
-}
-
-repositories {
-    jcenter()
-}
-
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+  compileSdkVersion rootProject.ext.compileSdkVersion
+  buildToolsVersion rootProject.ext.buildToolsVersion
 
-    defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 22
-        versionCode 1
-        versionName "1.0"
-    }
+  defaultConfig {
+    minSdkVersion rootProject.ext.minSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
+    versionCode 1
+    versionName '1.0'
+  }
+}
+
+repositories {
+  mavenCentral()
 }
 
 dependencies {
-    compile project(':rxandroid')
+  compile project(':rxandroid')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name='rxandroid-root'
 
-include 'rxandroid'
-include 'sample-app'
+include ':rxandroid'
+include ':sample-app'


### PR DESCRIPTION
Also updated to latest & greatest dependencies while I was at it.

This PR gets rid of [gradle-rxjava-project-plugin](https://github.com/nebula-plugins/gradle-rxjava-project-plugin) because it's incompatible with the Android build plugins. It's actually a smorgasbord of plugins, some of which seem to be geared only towards the Java plugin.

I think we'll end up having to import the individual plugins as necessary for release. I'm thinking we can handle that in parallel with other development; having this library work easily in Android Studio should really help out development.