### PR TITLE
Remove targetSdkVersion from library.

### DIFF
--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -6,7 +6,6 @@ android {
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
     }
 
     compileOptions {


### PR DESCRIPTION
This value participates in manifest merging downstream and while I'm a strong advocate for always targetting the latest, we gain nothing by specifying it and will inevitably cause someone a merging error.