### PR TITLE
Remove property-based hook configuration option.

### DIFF
--- a/rxandroid/src/main/java/rx/android/plugins/RxAndroidPlugins.java
+++ b/rxandroid/src/main/java/rx/android/plugins/RxAndroidPlugins.java
@@ -13,6 +13,7 @@
  */
 package rx.android.plugins;
 
+import rx.annotations.Beta;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -20,8 +21,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * correct implementation based on order of precedence:
  * <ol>
  * <li>plugin registered globally via {@code register} methods in this class</li>
- * <li>plugin registered and retrieved using {@link System#getProperty(String)} (see get methods
- * for property names)</li>
  * <li>default implementation</li>
  * </ol>
  */
@@ -38,7 +37,13 @@ public final class RxAndroidPlugins {
     RxAndroidPlugins() {
     }
 
-    void reset() {
+    /**
+     * Reset any explicit or default-set hooks.
+     * <p>
+     * Note: This should only be used for testing purposes.
+     */
+    @Beta
+    public void reset() {
         schedulersHook.set(null);
     }
 
@@ -52,18 +57,9 @@ public final class RxAndroidPlugins {
      */
     public RxAndroidSchedulersHook getSchedulersHook() {
         if (schedulersHook.get() == null) {
-            // Check for an implementation from System.getProperty first.
-            RxAndroidSchedulersHook impl =
-                    getPluginImplementationViaProperty(RxAndroidSchedulersHook.class);
-            if (impl == null) {
-                // Nothing set via properties so initialize with default.
-                schedulersHook.compareAndSet(null, RxAndroidSchedulersHook.getDefaultInstance());
-                // We don't return from here but call get() again in case of thread-race so the winner will
-                // always get returned.
-            } else {
-                // We received an implementation from the system property so use it.
-                schedulersHook.compareAndSet(null, impl);
-            }
+            schedulersHook.compareAndSet(null, RxAndroidSchedulersHook.getDefaultInstance());
+            // We don't return from here but call get() again in case of thread-race so the winner will
+            // always get returned.
         }
         return schedulersHook.get();
     }
@@ -79,44 +75,6 @@ public final class RxAndroidPlugins {
         if (!schedulersHook.compareAndSet(null, impl)) {
             throw new IllegalStateException(
                     "Another strategy was already registered: " + schedulersHook.get());
-        }
-    }
-
-    @SuppressWarnings("unchecked") // Burden of correctness is on the property setter.
-    private static <T> T getPluginImplementationViaProperty(Class<T> pluginClass) {
-        String classSimpleName = pluginClass.getSimpleName();
-        // Check system properties for plugin class. This will only happen during system startup thus
-        // it's okay to use the synchronized System.getProperties as it will never get called in
-        // normal operations.
-        String implementingClass =
-                System.getProperty("rxandroid.plugin." + classSimpleName + ".implementation");
-        if (implementingClass != null) {
-            try {
-                Class<?> cls = Class.forName(implementingClass);
-                // narrow the scope (cast) to the type we're expecting
-                cls = cls.asSubclass(pluginClass);
-                return (T) cls.newInstance();
-            } catch (ClassCastException e) {
-                throw new RuntimeException(classSimpleName
-                        + " implementation is not an instance of "
-                        + classSimpleName
-                        + ": "
-                        + implementingClass);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(classSimpleName
-                        + " implementation class not found: "
-                        + implementingClass, e);
-            } catch (InstantiationException e) {
-              throw new RuntimeException(classSimpleName
-                      + " implementation not able to be instantiated: "
-                      + implementingClass, e);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(classSimpleName
-                        + " implementation not able to be accessed: "
-                        + implementingClass, e);
-            }
-        } else {
-            return null;
         }
     }
 }

--- a/rxandroid/src/test/java/rx/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/rx/android/plugins/RxAndroidPluginsTest.java
@@ -23,14 +23,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public final class RxAndroidPluginsTest {
-    /** Reset plugins. Used by other tests which need to register hooks. */
-    public static void resetPlugins() {
-        RxAndroidPlugins.getInstance().reset();
-    }
-
     @Before @After
     public void setUpAndTearDown() {
-        resetPlugins();
+        RxAndroidPlugins.getInstance().reset();
     }
 
     @Test
@@ -39,17 +34,6 @@ public final class RxAndroidPluginsTest {
         RxAndroidSchedulersHook hook = new RxAndroidSchedulersHook();
         plugins.registerSchedulersHook(hook);
         assertSame(hook, plugins.getSchedulersHook());
-    }
-
-    @Test
-    public void registerSchedulersHookViaSystemProperty() {
-        System.setProperty("rxandroid.plugin.RxAndroidSchedulersHook.implementation",
-                "rx.android.plugins.RxAndroidPluginsTest$CustomHook");
-        assertEquals(CustomHook.class,
-                RxAndroidPlugins.getInstance().getSchedulersHook().getClass());
-    }
-
-    static class CustomHook extends RxAndroidSchedulersHook {
     }
 
     @Test

--- a/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
@@ -33,7 +33,7 @@ public class AndroidSchedulersTest {
 
     @Before @After
     public void setUpAndTearDown() {
-        RxAndroidPluginsTest.resetPlugins();
+        RxAndroidPlugins.getInstance().reset();
     }
 
     @Test

--- a/rxandroid/src/test/java/rx/android/schedulers/HandlerSchedulerTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/HandlerSchedulerTest.java
@@ -51,7 +51,7 @@ public class HandlerSchedulerTest {
 
     @Before @After
     public void setUpAndTearDown() {
-        RxAndroidPluginsTest.resetPlugins();
+        RxAndroidPlugins.getInstance().reset();
     }
 
     @Test


### PR DESCRIPTION
Android restricts properties to 32 characters which means these never could be set. Additionally, using properties to control behvior on Android has little precedent so we favor explicit APIs instead. If this every changes, the behavior can be changed in a backwards compatible way whereas including them as-is would prevent future removal.

Additionally, we expose the  method as a beta API. The discussion around exposing a method like this for RxJava is ongoing.