### PR TITLE
Fixed race condition between unsubscribe() and postDelayed()

### DIFF
--- a/rxandroid/src/main/java/rx/android/schedulers/HandlerScheduler.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/HandlerScheduler.java
@@ -72,16 +72,17 @@ public final class HandlerScheduler extends Scheduler {
             action = RxAndroidPlugins.getInstance().getSchedulersHook().onSchedule(action);
 
             final ScheduledAction scheduledAction = new ScheduledAction(action);
+            scheduledAction.addParent(compositeSubscription);
+            compositeSubscription.add(scheduledAction);
+
+            handler.postDelayed(scheduledAction, unit.toMillis(delayTime));
+
             scheduledAction.add(Subscriptions.create(new Action0() {
                 @Override
                 public void call() {
                     handler.removeCallbacks(scheduledAction);
                 }
             }));
-            scheduledAction.addParent(compositeSubscription);
-            compositeSubscription.add(scheduledAction);
-
-            handler.postDelayed(scheduledAction, unit.toMillis(delayTime));
 
             return scheduledAction;
         }


### PR DESCRIPTION
Fixed a finer point from #214.

We now guarantee that removeCallbacks() is called *after* the message is posted to the Handler. That way there's no possibility of removeCallbacks() being called before the message is posted (thus causing the message to occur anyways).