### PR TITLE
Lazily initialize MAIN_THREAD_SCHEDULER to avoid class loading problems in unit tests

### DIFF
--- a/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -13,9 +13,10 @@
  */
 package rx.android.schedulers;
 
-import rx.Scheduler;
 import android.os.Handler;
 import android.os.Looper;
+
+import rx.Scheduler;
 import rx.android.plugins.RxAndroidPlugins;
 
 /** Android-specific Schedulers. */
@@ -24,13 +25,17 @@ public final class AndroidSchedulers {
         throw new AssertionError("No instances");
     }
 
-    private static final Scheduler MAIN_THREAD_SCHEDULER =
-            new HandlerScheduler(new Handler(Looper.getMainLooper()));
+    // See https://github.com/ReactiveX/RxAndroid/issues/238
+    // https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom
+    private static class MainThreadSchedulerHolder {
+        static final Scheduler MAIN_THREAD_SCHEDULER =
+                new HandlerScheduler(new Handler(Looper.getMainLooper()));
+    }
 
     /** A {@link Scheduler} which executes actions on the Android UI thread. */
     public static Scheduler mainThread() {
         Scheduler scheduler =
                 RxAndroidPlugins.getInstance().getSchedulersHook().getMainThreadScheduler();
-        return scheduler != null ? scheduler : MAIN_THREAD_SCHEDULER;
+        return scheduler != null ? scheduler : MainThreadSchedulerHolder.MAIN_THREAD_SCHEDULER;
     }
 }

--- a/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
@@ -16,19 +16,14 @@ package rx.android.schedulers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
+
 import rx.Scheduler;
 import rx.android.plugins.RxAndroidPlugins;
-import rx.android.plugins.RxAndroidPluginsTest;
 import rx.android.plugins.RxAndroidSchedulersHook;
-import rx.schedulers.Schedulers;
 
 import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest=Config.NONE)
 public class AndroidSchedulersTest {
 
     @Before @After
@@ -38,13 +33,12 @@ public class AndroidSchedulersTest {
 
     @Test
     public void mainThreadCallsThroughToHook() {
-        final Scheduler scheduler = Schedulers.immediate();
-        RxAndroidSchedulersHook hook = new RxAndroidSchedulersHook() {
+        final Scheduler scheduler = mock(Scheduler.class);
+        RxAndroidPlugins.getInstance().registerSchedulersHook(new RxAndroidSchedulersHook() {
             @Override public Scheduler getMainThreadScheduler() {
                 return scheduler;
             }
-        };
-        RxAndroidPlugins.getInstance().registerSchedulersHook(hook);
+        });
 
         Scheduler mainThread = AndroidSchedulers.mainThread();
         assertSame(scheduler, mainThread);


### PR DESCRIPTION
Fixes #238.