### PR TITLE
Prepare version 1.1.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 # RxAndroid Releases #
 
-### Version 1.0.1 - August 9th 2015 ####
+### Version 1.1.0 - December 9th 2015 ###
+
+ * New: `MainThreadSubscription` utility class runs its `onUnsubscribe` action on the Android main
+   thread. This aids in adding tear-down actions which must be executed on the main thread without
+   having to deal with posting to the main thread yourself.
+ * RxJava dependency now points at v1.1.0.
+
+
+### Version 1.0.1 - August 9th 2015 ###
 
  * Fix: Correctly check `isUnsubscribed()` state in `HandlerScheduler`'s worker before scheduling
    more work.
@@ -8,7 +16,7 @@
    be canceled on unsubscription.
 
 
-### Version 1.0.0 - August 5th 2015 ####
+### Version 1.0.0 - August 5th 2015 ###
 
 Initial stable release!
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Since RxAndroid is part of the RxJava family the communication channels are simi
 # Binaries
 
 ```groovy
-compile 'io.reactivex:rxandroid:1.0.1'
+compile 'io.reactivex:rxandroid:1.1.0'
 // Because RxAndroid releases are few and far between, it is recommended you also
 // explicitly depend on RxJava's latest version for bug fixes and new features.
-compile 'io.reactivex:rxjava:1.0.16'
+compile 'io.reactivex:rxjava:1.1.0'
 ```
 
 * RxAndroid: <a href='http://search.maven.org/#search%7Cga%7C1%7Crxandroid'><img src='http://img.shields.io/maven-central/v/io.reactivex/rxandroid.svg'></a>

--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -47,7 +47,7 @@ repositories {
 }
 
 dependencies {
-    compile 'io.reactivex:rxjava:1.0.16'
+    compile 'io.reactivex:rxjava:1.1.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
* Bump RxJava dependency to 1.1.0.
* Update CHANGELOG with new changes.