### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/rxandroid/src/main/java/rx/android/plugins/RxAndroidPlugins.java
+++ b/rxandroid/src/main/java/rx/android/plugins/RxAndroidPlugins.java
@@ -54,6 +54,8 @@ public final class RxAndroidPlugins {
      * Override the default by calling {@link #registerSchedulersHook(RxAndroidSchedulersHook)} or by
      * setting the property {@code rxandroid.plugin.RxAndroidSchedulersHook.implementation} with the
      * full classname to load.
+     *
+     * @return The {@link RxAndroidSchedulersHook} instance
      */
     public RxAndroidSchedulersHook getSchedulersHook() {
         if (schedulersHook.get() == null) {
@@ -68,6 +70,7 @@ public final class RxAndroidPlugins {
      * Registers an {@link RxAndroidSchedulersHook} implementation as a global override of any
      * injected or default implementations.
      *
+     * @param impl The {@link RxAndroidSchedulersHook} implementation
      * @throws IllegalStateException if called more than once or after the default was initialized
      * (if usage occurs before trying to register)
      */

--- a/rxandroid/src/main/java/rx/android/plugins/RxAndroidSchedulersHook.java
+++ b/rxandroid/src/main/java/rx/android/plugins/RxAndroidSchedulersHook.java
@@ -29,6 +29,8 @@ public class RxAndroidSchedulersHook {
      * should be used.
      * <p>
      * This instance should be or behave like a stateless singleton.
+     *
+     * @return The main thread {@link Scheduler}
      */
     public Scheduler getMainThreadScheduler() {
         return null;

--- a/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -32,7 +32,11 @@ public final class AndroidSchedulers {
                 new HandlerScheduler(new Handler(Looper.getMainLooper()));
     }
 
-    /** A {@link Scheduler} which executes actions on the Android UI thread. */
+    /**
+     * A {@link Scheduler} which executes actions on the Android UI thread.
+     *
+     * @return A main thread {@link Scheduler}
+     */
     public static Scheduler mainThread() {
         Scheduler scheduler =
                 RxAndroidPlugins.getInstance().getSchedulersHook().getMainThreadScheduler();

--- a/rxandroid/src/main/java/rx/android/schedulers/HandlerScheduler.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/HandlerScheduler.java
@@ -26,7 +26,12 @@ import android.os.Handler;
 
 /** A {@link Scheduler} backed by a {@link Handler}. */
 public final class HandlerScheduler extends Scheduler {
-    /** Create a {@link Scheduler} which uses {@code handler} to execute actions. */
+    /**
+     * Create a {@link Scheduler} which uses {@code handler} to execute actions.
+     *
+     * @param handler The {@link Handler} to execute actions
+     * @return A new {@link HandlerScheduler}
+     */
     public static HandlerScheduler from(Handler handler) {
         if (handler == null) throw new NullPointerException("handler == null");
         return new HandlerScheduler(handler);


### PR DESCRIPTION
Building the project will output in the following warnings:

    <...>/rx/android/schedulers/AndroidSchedulers.java:36: warning: no @return
        public static Scheduler mainThread() {
                                ^
    <...>/rx/android/schedulers/HandlerScheduler.java:30: warning: no @param for handler
        public static HandlerScheduler from(Handler handler) {
                                       ^
    <...>/rx/android/schedulers/HandlerScheduler.java:30: warning: no @return
        public static HandlerScheduler from(Handler handler) {
                                       ^
    <...>/rx/android/plugins/RxAndroidPlugins.java:58: warning: no @return
        public RxAndroidSchedulersHook getSchedulersHook() {
                                       ^
    <...>/rx/android/plugins/RxAndroidPlugins.java:74: warning: no @param for impl
        public void registerSchedulersHook(RxAndroidSchedulersHook impl) {
                    ^
    <...>/rx/android/plugins/RxAndroidSchedulersHook.java:33: warning: no @return
        public Scheduler getMainThreadScheduler() {
                         ^
    6 warnings

Given that [Javadoc](http://www.oracle.com/technetwork/articles/java/index-137868.html) is a relatively well defined standard (e.g. in regards to which tags are required and which are optional), there should be no reason to have documentation that litters the build log with warnings.

In an attempt to fix these warnings, this pull request just adds the missing `@param` and `@return` tags with short descriptions taken from the main documentation. As @JakeWharton in #246 correctly criticized, this creates some redundancies. Two other possible solutions I can think of would be to reword the main documentation in order to decrease the redundancy, or to configure the javadoc tool to ignore these issues altogether and not output warnings. Open to other suggestions as well.