### PR TITLE
BackgroundThreadScheduler - work on thread with lower priority

### DIFF
--- a/rxandroid/src/main/java/rx/android/plugins/RxAndroidSchedulersHook.java
+++ b/rxandroid/src/main/java/rx/android/plugins/RxAndroidSchedulersHook.java
@@ -35,6 +35,16 @@ public class RxAndroidSchedulersHook {
     }
 
     /**
+     * Scheduler to return from {@link AndroidSchedulers#backgroundThread()} ()} or {@code null} if default
+     * should be used.
+     * <p>
+     * This instance should be or behave like a stateless singleton.
+     */
+    public Scheduler getBackgroundThreadScheduler() {
+        return null;
+    }
+
+    /**
      * Invoked before the Action is handed over to the scheduler.  Can be used for
      * wrapping/decorating/logging. The default is just a passthrough.
      *

--- a/rxandroid/src/main/java/rx/android/schedulers/background/BackgroundThreadFactory.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/background/BackgroundThreadFactory.java
@@ -1,0 +1,26 @@
+package rx.android.schedulers.background;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Thread factory which creates threads with lowered priority ({@link Thread#NORM_PRIORITY} - 1)
+ */
+public final class BackgroundThreadFactory extends AtomicLong implements ThreadFactory {
+    final String prefix;
+    final static int BACKGROUND_THREAD_PRIORITY = Thread.NORM_PRIORITY - 1;
+
+    public BackgroundThreadFactory(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        Thread t = new Thread(r, prefix + incrementAndGet());
+        if (t.getPriority() != BACKGROUND_THREAD_PRIORITY) {
+            t.setPriority(BACKGROUND_THREAD_PRIORITY);
+        }
+        t.setDaemon(true);
+        return t;
+    }
+}

--- a/rxandroid/src/main/java/rx/android/schedulers/background/BackgroundThreadScheduler.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/background/BackgroundThreadScheduler.java
@@ -1,0 +1,27 @@
+package rx.android.schedulers.background;
+
+import rx.Scheduler;
+import rx.internal.schedulers.NewThreadWorker;
+
+/**
+ * Schedules each unit of work on a new thread. Threads created by this scheduler will
+ * have fixed priority ({@link Thread#NORM_PRIORITY} - 1) which is lower than Android
+ * main thread priority.
+ */
+public class BackgroundThreadScheduler extends Scheduler {
+
+    private static final String THREAD_NAME_PREFIX = "RxAndroidBackgroundThreadScheduler-";
+    private static final BackgroundThreadFactory THREAD_FACTORY = new BackgroundThreadFactory(THREAD_NAME_PREFIX);
+
+    public static BackgroundThreadScheduler newInstance() {
+        return new BackgroundThreadScheduler();
+    }
+
+    private BackgroundThreadScheduler() {
+    }
+
+    @Override
+    public Worker createWorker() {
+        return new NewThreadWorker(THREAD_FACTORY);
+    }
+}

--- a/rxandroid/src/main/java/rx/android/schedulers/handler/HandlerScheduler.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/handler/HandlerScheduler.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.android.schedulers;
+package rx.android.schedulers.handler;
 
 import java.util.concurrent.TimeUnit;
 

--- a/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
@@ -43,4 +43,17 @@ public class AndroidSchedulersTest {
         Scheduler mainThread = AndroidSchedulers.mainThread();
         assertSame(scheduler, mainThread);
     }
+
+    @Test
+    public void backgroundThreadCallsThroughToHook() {
+        final Scheduler scheduler = mock(Scheduler.class);
+        RxAndroidPlugins.getInstance().registerSchedulersHook(new RxAndroidSchedulersHook() {
+            @Override public Scheduler getBackgroundThreadScheduler() {
+                return scheduler;
+            }
+        });
+
+        Scheduler backgroundThread = AndroidSchedulers.backgroundThread();
+        assertSame(scheduler, backgroundThread);
+    }
 }

--- a/rxandroid/src/test/java/rx/android/schedulers/background/BackgroundThreadSchedulerTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/background/BackgroundThreadSchedulerTest.java
@@ -1,0 +1,120 @@
+package rx.android.schedulers.background;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import rx.Scheduler.Worker;
+import rx.android.plugins.RxAndroidPlugins;
+import rx.functions.Action0;
+import rx.plugins.RxJavaPlugins;
+import rx.plugins.RxJavaSchedulersHook;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class BackgroundThreadSchedulerTest {
+
+    @Before @After
+    public void setUpAndTearDown() {
+        RxAndroidPlugins.getInstance().reset();
+    }
+
+    @Test
+    public void newInstanceWorks() {
+        BackgroundThreadScheduler scheduler = BackgroundThreadScheduler.newInstance();
+        assertNotNull(scheduler);
+    }
+
+    @Test
+    public void testScheduledThroughHook() throws InterruptedException {
+        Action0 action = mock(Action0.class);
+        final AtomicReference<Action0> ref = new AtomicReference<>();
+
+        RxJavaPlugins.getInstance().registerSchedulersHook(new RxJavaSchedulersHook() {
+            @Override public Action0 onSchedule(Action0 action) {
+                ref.set(action);
+                return action;
+            }
+        });
+
+        BackgroundThreadScheduler scheduler = BackgroundThreadScheduler.newInstance();
+        Worker worker = scheduler.createWorker();
+        worker.schedule(action);
+
+        assertSame(action, ref.get());
+    }
+
+    @Test
+    public void testActionIsCalled() throws InterruptedException {
+        BackgroundThreadScheduler scheduler = BackgroundThreadScheduler.newInstance();
+        Worker worker = scheduler.createWorker();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean isCalled = new AtomicBoolean(false);
+        Action0 action = new Action0() {
+            @Override public void call() {
+                isCalled.set(true);
+                latch.countDown();
+            }
+        };
+
+        worker.schedule(action);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertTrue(isCalled.get());
+    }
+
+    @Test
+    public void testThreadIsDifferent() throws InterruptedException {
+        BackgroundThreadScheduler scheduler = BackgroundThreadScheduler.newInstance();
+        Worker worker = scheduler.createWorker();
+
+        final AtomicLong backgroundThreadId = new AtomicLong();
+        final CountDownLatch latch = new CountDownLatch(1);
+        Action0 action = new Action0() {
+            @Override public void call() {
+                backgroundThreadId.set(Thread.currentThread().getId());
+                latch.countDown();
+            }
+        };
+        worker.schedule(action);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertNotEquals(Thread.currentThread().getId(), backgroundThreadId.get());
+    }
+
+    @Test
+    public void testThreadPriority() throws InterruptedException {
+        BackgroundThreadScheduler scheduler = BackgroundThreadScheduler.newInstance();
+        Worker worker = scheduler.createWorker();
+
+        final AtomicInteger backgroundThreadPriority = new AtomicInteger();
+        final CountDownLatch latch = new CountDownLatch(1);
+        Action0 action = new Action0() {
+            @Override public void call() {
+                backgroundThreadPriority.set(Thread.currentThread().getPriority());
+                latch.countDown();
+            }
+        };
+        worker.schedule(action);
+
+        latch.await(1, TimeUnit.SECONDS);
+        assertEquals(Thread.NORM_PRIORITY - 1, backgroundThreadPriority.get());
+    }
+}

--- a/rxandroid/src/test/java/rx/android/schedulers/handler/HandlerSchedulerTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/handler/HandlerSchedulerTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.android.schedulers;
+package rx.android.schedulers.handler;
 
 import android.os.Handler;
 import org.junit.After;
@@ -30,6 +30,7 @@ import rx.Subscriber;
 import rx.Subscription;
 import rx.android.plugins.RxAndroidPlugins;
 import rx.android.plugins.RxAndroidSchedulersHook;
+import rx.android.schedulers.handler.HandlerScheduler;
 import rx.functions.Action0;
 
 import java.util.concurrent.TimeUnit;

--- a/sample-app/src/main/java/rx/android/samples/MainActivity.java
+++ b/sample-app/src/main/java/rx/android/samples/MainActivity.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Observable;
 import rx.Subscriber;
 import rx.android.schedulers.AndroidSchedulers;
-import rx.android.schedulers.HandlerScheduler;
+import rx.android.schedulers.handler.HandlerScheduler;
 import rx.exceptions.OnErrorThrowable;
 import rx.functions.Func0;
 


### PR DESCRIPTION
As per Android performance guidelines, background work should be scheduled on thread with lower (compared to the main thread) priority, so it doesn't interfere with the main thread. Actually, systrace even has an alert for this:

> Work to produce this frame was descheduled for several milliseconds, contributing to jank. Ensure that code on the UI thread doesn't block on work being done on other threads, and that background threads (doing e.g. network or bitmap loading) are running at android.os.Process#THREAD_PRIORITY_BACKGROUND or lower so they are less likely to interrupt the UI thread. These background threads should show up with a priority number of 130 or higher in the scheduling section under the Kernel process.

BackgroundThreadScheduler is intended to solve this by using custom `ThreadFactory` which creates threads with lowered priority.

You can get an instance of this scheduler by `AndroidSchedulers.backgroundThread()`