### PR TITLE
Cache the hook reference upon worker creation.

### DIFF
--- a/rxandroid/src/main/java/rx/android/schedulers/HandlerScheduler.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/HandlerScheduler.java
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 import rx.Scheduler;
 import rx.Subscription;
 import rx.android.plugins.RxAndroidPlugins;
+import rx.android.plugins.RxAndroidSchedulersHook;
 import rx.exceptions.OnErrorNotImplementedException;
 import rx.functions.Action0;
 import rx.plugins.RxJavaPlugins;
@@ -46,10 +47,12 @@ public final class HandlerScheduler extends Scheduler {
 
     static class HandlerWorker extends Worker {
         private final Handler handler;
+        private final RxAndroidSchedulersHook hook;
         private volatile boolean unsubscribed;
 
         HandlerWorker(Handler handler) {
             this.handler = handler;
+            this.hook = RxAndroidPlugins.getInstance().getSchedulersHook();
         }
 
         @Override
@@ -69,7 +72,7 @@ public final class HandlerScheduler extends Scheduler {
                 return Subscriptions.unsubscribed();
             }
 
-            action = RxAndroidPlugins.getInstance().getSchedulersHook().onSchedule(action);
+            action = hook.onSchedule(action);
 
             ScheduledAction scheduledAction = new ScheduledAction(action, handler);
 

--- a/rxandroid/src/test/java/rx/android/schedulers/HandlerSchedulerTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/HandlerSchedulerTest.java
@@ -165,15 +165,17 @@ public class HandlerSchedulerTest {
 
     @Test
     public void workerUnsubscriptionDuringSchedulingCancelsScheduledAction() {
-        final Scheduler.Worker worker = scheduler.createWorker();
-
+        final AtomicReference<Scheduler.Worker> workerRef = new AtomicReference<>();
         RxAndroidPlugins.getInstance().registerSchedulersHook(new RxAndroidSchedulersHook() {
             @Override public Action0 onSchedule(Action0 action) {
                 // Purposefully unsubscribe in an asinine point after the normal unsubscribed check.
-                worker.unsubscribe();
+                workerRef.get().unsubscribe();
                 return super.onSchedule(action);
             }
         });
+
+        Scheduler.Worker worker = scheduler.createWorker();
+        workerRef.set(worker);
 
         Action0 action = mock(Action0.class);
         worker.schedule(action);
@@ -223,7 +225,7 @@ public class HandlerSchedulerTest {
 
     @Test public void throwingActionRoutedToHookAndThreadHandler() {
         // TODO Test hook as well. Requires https://github.com/ReactiveX/RxJava/pull/3820.
-        
+
         Thread thread = Thread.currentThread();
         UncaughtExceptionHandler originalHandler = thread.getUncaughtExceptionHandler();
 


### PR DESCRIPTION
There's no need to look it up each time since it can't change.