### PR TITLE
Add AndroidSchedulers.reset() for better testing support

### DIFF
--- a/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -64,9 +64,9 @@ public final class AndroidSchedulers {
     }
 
     /**
-     * Reset any cached schedulers.
-     * <p>
-     * Note: This should only be used for testing purposes.
+     * Resets the current {@link AndroidSchedulers} instance.
+     * This will re-init the cached schedulers on the next usage,
+     * which can be useful in testing.
      */
     @Experimental
     public static void reset() {

--- a/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -21,7 +21,6 @@ import rx.Scheduler;
 import rx.android.plugins.RxAndroidPlugins;
 import rx.android.plugins.RxAndroidSchedulersHook;
 import rx.annotations.Experimental;
-import rx.schedulers.Schedulers;
 
 /** Android-specific Schedulers. */
 public final class AndroidSchedulers {
@@ -65,12 +64,9 @@ public final class AndroidSchedulers {
     }
 
     /**
-     * Resets the current {@link Schedulers} instance.
+     * Reset any cached schedulers.
      * <p>
-     * This API is experimental. Resetting the schedulers is dangerous
-     * during application runtime and also bad code could invoke it in
-     * the middle of an application life-cycle and really break applications
-     * if not used cautiously.
+     * Note: This should only be used for testing purposes.
      */
     @Experimental
     public static void reset() {

--- a/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -14,15 +14,25 @@
 package rx.android.schedulers;
 
 import android.os.Looper;
+
 import rx.Scheduler;
 import rx.android.plugins.RxAndroidPlugins;
 import rx.android.plugins.RxAndroidSchedulersHook;
+import rx.annotations.Experimental;
+import rx.schedulers.Schedulers;
 
 /** Android-specific Schedulers. */
 public final class AndroidSchedulers {
-    private static final AndroidSchedulers INSTANCE = new AndroidSchedulers();
+    private static AndroidSchedulers INSTANCE = new AndroidSchedulers();
 
     private final Scheduler mainThreadScheduler;
+
+    private static synchronized AndroidSchedulers getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new AndroidSchedulers();
+        }
+        return INSTANCE;
+    }
 
     private AndroidSchedulers() {
         RxAndroidSchedulersHook hook = RxAndroidPlugins.getInstance().getSchedulersHook();
@@ -37,12 +47,25 @@ public final class AndroidSchedulers {
 
     /** A {@link Scheduler} which executes actions on the Android UI thread. */
     public static Scheduler mainThread() {
-        return INSTANCE.mainThreadScheduler;
+        return getInstance().mainThreadScheduler;
     }
 
     /** A {@link Scheduler} which executes actions on {@code looper}. */
     public static Scheduler from(Looper looper) {
         if (looper == null) throw new NullPointerException("looper == null");
         return new LooperScheduler(looper);
+    }
+
+    /**
+     * Resets the current {@link Schedulers} instance.
+     * <p>
+     * This API is experimental. Resetting the schedulers is dangerous
+     * during application runtime and also bad code could invoke it in
+     * the middle of an application life-cycle and really break applications
+     * if not used cautiously.
+     */
+    @Experimental
+    public static void reset() {
+        INSTANCE = null;
     }
 }

--- a/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -15,6 +15,8 @@ package rx.android.schedulers;
 
 import android.os.Looper;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import rx.Scheduler;
 import rx.android.plugins.RxAndroidPlugins;
 import rx.android.plugins.RxAndroidSchedulersHook;
@@ -23,15 +25,21 @@ import rx.schedulers.Schedulers;
 
 /** Android-specific Schedulers. */
 public final class AndroidSchedulers {
-    private static AndroidSchedulers INSTANCE = new AndroidSchedulers();
+    private static final AtomicReference<AndroidSchedulers> INSTANCE = new AtomicReference<>();
 
     private final Scheduler mainThreadScheduler;
 
-    private static synchronized AndroidSchedulers getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new AndroidSchedulers();
+    private static AndroidSchedulers getInstance() {
+        for (;;) {
+            AndroidSchedulers current = INSTANCE.get();
+            if (current != null) {
+                return current;
+            }
+            current = new AndroidSchedulers();
+            if (INSTANCE.compareAndSet(null, current)) {
+                return current;
+            }
         }
-        return INSTANCE;
     }
 
     private AndroidSchedulers() {
@@ -66,6 +74,6 @@ public final class AndroidSchedulers {
      */
     @Experimental
     public static void reset() {
-        INSTANCE = null;
+        INSTANCE.set(null);
     }
 }

--- a/rxandroid/src/test/java/rx/android/schedulers/ResetSchedulersTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/ResetSchedulersTest.java
@@ -1,5 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package rx.android.schedulers;
-
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,6 +23,7 @@ import rx.android.plugins.RxAndroidPlugins;
 import rx.android.plugins.RxAndroidSchedulersHook;
 import rx.schedulers.TestScheduler;
 
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
@@ -30,7 +43,7 @@ public final class ResetSchedulersTest {
         });
         AndroidSchedulers.reset();
 
-        assertTrue(AndroidSchedulers.mainThread().equals(testScheduler));
+        assertSame(AndroidSchedulers.mainThread(), testScheduler);
 
         RxAndroidPlugins.getInstance().reset();
         RxAndroidPlugins.getInstance().registerSchedulersHook(RxAndroidSchedulersHook.getDefaultInstance());

--- a/rxandroid/src/test/java/rx/android/schedulers/ResetSchedulersTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/ResetSchedulersTest.java
@@ -1,0 +1,42 @@
+package rx.android.schedulers;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import rx.Scheduler;
+import rx.android.plugins.RxAndroidPlugins;
+import rx.android.plugins.RxAndroidSchedulersHook;
+import rx.schedulers.TestScheduler;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public final class ResetSchedulersTest {
+
+    @Test
+    public void reset() {
+        RxAndroidPlugins.getInstance().reset();
+
+        final TestScheduler testScheduler = new TestScheduler();
+        RxAndroidPlugins.getInstance().registerSchedulersHook(new RxAndroidSchedulersHook() {
+            @Override
+            public Scheduler getMainThreadScheduler() {
+                return testScheduler;
+            }
+        });
+        AndroidSchedulers.reset();
+
+        assertTrue(AndroidSchedulers.mainThread().equals(testScheduler));
+
+        RxAndroidPlugins.getInstance().reset();
+        RxAndroidPlugins.getInstance().registerSchedulersHook(RxAndroidSchedulersHook.getDefaultInstance());
+        AndroidSchedulers.reset();
+
+        assertTrue(AndroidSchedulers.mainThread() instanceof LooperScheduler);
+    }
+
+}


### PR DESCRIPTION
Corresponds to https://github.com/ReactiveX/RxJava/pull/3986

This adds a `reset()` method to `AndroidSchedulers`, with the main benefit being improved testing support. This does slightly tweak the internal API of `AndroidSchedulers` to use a `getInstance()` approach to allow lazy init. This way we don't have to replace the singleton instance during `reset()` and allow it to lazily re-evaluate upon next usage. Otherwise, if you change your scheduler hook, you'd always have to make sure you set it before you call `Schedulers.reset()`.