### PR TITLE
1.x: Add RxAndroidHooks to make RxAndroid API consistent with RxJava 1.x

### DIFF
--- a/rxandroid/src/main/java/rx/android/plugins/RxAndroidHooks.java
+++ b/rxandroid/src/main/java/rx/android/plugins/RxAndroidHooks.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.plugins;
+
+import rx.Scheduler;
+import rx.annotations.Experimental;
+import rx.functions.Func1;
+
+/**
+ * Utility class that holds hooks for Scheduler.
+ * <p>
+ * The class features a lockdown state, see {@link #lockdown()} and {@link #isLockdown()}
+ * to prevent further changes to the hooks.
+ */
+@Experimental
+public final class RxAndroidHooks {
+    /**
+     * Prevents changing the hook callbacks when set to true.
+     */
+    static volatile boolean lockdown;
+
+    static volatile Func1<Scheduler, Scheduler> onMainScheduler;
+
+    private RxAndroidHooks() {
+        throw new IllegalStateException("No instances!");
+    }
+
+    /**
+     * Returns the current main scheduler hook function or null if it is
+     * set to the default pass-through.
+     * <p>
+     * This operation is threadsafe.
+     * @return the current hook function
+     */
+    public static Func1<Scheduler, Scheduler> getOnMainScheduler() {
+        return onMainScheduler;
+    }
+
+    /**
+     * Sets the hook function for returning a scheduler when
+     * the AndroidSchedulers.mainThread() is called unless a lockdown is in effect.
+     * <p>
+     * This operation is threadsafe.
+     * <p>
+     * Calling with a {@code null} parameter restores the default behavior:
+     * the hook returns the same object.
+     * @param onMainScheduler the function that receives the original
+     * Android main scheduler and should return a scheduler
+     */
+    public static void setOnMainScheduler(Func1<Scheduler, Scheduler> onMainScheduler) {
+        if (lockdown) {
+            return;
+        }
+        RxAndroidHooks.onMainScheduler = onMainScheduler;
+    }
+
+    /**
+     * Hook to call when the AndroidSchedulers.mainThread() is called.
+     * @param scheduler the default Android main scheduler
+     * @return the default of alternative scheduler
+     */
+    public static Scheduler onMainScheduler(Scheduler scheduler) {
+        Func1<Scheduler, Scheduler> f = RxAndroidHooks.onMainScheduler;
+        if (f != null) {
+            return f.call(scheduler);
+        }
+        return scheduler;
+    }
+
+    /**
+     * Reset all hook callbacks to those of the current RxAndroidPlugins handlers.
+     */
+    public static void reset() {
+        if (lockdown) {
+            return;
+        }
+        onMainScheduler = null;
+    }
+
+    /**
+     * Prevents changing the hooks.
+     */
+    public static void lockdown() {
+        lockdown = true;
+    }
+
+    /**
+     * Returns true if the hooks can no longer be changed.
+     */
+    public static boolean isLockdown() {
+        return lockdown;
+    }
+}

--- a/rxandroid/src/main/java/rx/android/plugins/RxAndroidPlugins.java
+++ b/rxandroid/src/main/java/rx/android/plugins/RxAndroidPlugins.java
@@ -27,6 +27,12 @@ import rx.annotations.Experimental;
 public final class RxAndroidPlugins {
     private static final RxAndroidPlugins INSTANCE = new RxAndroidPlugins();
 
+    /**
+     * Retrives the single {@code RxAndroidPlugins} instance.
+     *
+     * @deprecated use the static methods of {@link RxAndroidHooks}
+     */
+    @Deprecated
     public static RxAndroidPlugins getInstance() {
         return INSTANCE;
     }

--- a/rxandroid/src/main/java/rx/android/plugins/RxAndroidSchedulersHook.java
+++ b/rxandroid/src/main/java/rx/android/plugins/RxAndroidSchedulersHook.java
@@ -36,7 +36,7 @@ public class RxAndroidSchedulersHook {
 
     /**
      * Invoked before the Action is handed over to the scheduler.  Can be used for
-     * wrapping/decorating/logging. The default is just a passthrough.
+     * wrapping/decorating/logging. The default is just a pass-through.
      *
      * @param action action to schedule
      * @return wrapped action to schedule

--- a/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/rx/android/schedulers/AndroidSchedulers.java
@@ -18,6 +18,7 @@ import android.os.Looper;
 import java.util.concurrent.atomic.AtomicReference;
 
 import rx.Scheduler;
+import rx.android.plugins.RxAndroidHooks;
 import rx.android.plugins.RxAndroidPlugins;
 import rx.android.plugins.RxAndroidSchedulersHook;
 import rx.annotations.Experimental;
@@ -42,6 +43,7 @@ public final class AndroidSchedulers {
     }
 
     private AndroidSchedulers() {
+        @SuppressWarnings("deprecation")
         RxAndroidSchedulersHook hook = RxAndroidPlugins.getInstance().getSchedulersHook();
 
         Scheduler main = hook.getMainThreadScheduler();
@@ -54,7 +56,7 @@ public final class AndroidSchedulers {
 
     /** A {@link Scheduler} which executes actions on the Android UI thread. */
     public static Scheduler mainThread() {
-        return getInstance().mainThreadScheduler;
+        return RxAndroidHooks.onMainScheduler(getInstance().mainThreadScheduler);
     }
 
     /** A {@link Scheduler} which executes actions on {@code looper}. */

--- a/rxandroid/src/test/java/rx/android/plugins/RxAndroidHooksTest.java
+++ b/rxandroid/src/test/java/rx/android/plugins/RxAndroidHooksTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.android.plugins;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import rx.Scheduler;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.android.testutil.EmptyScheduler;
+import rx.functions.Func1;
+import rx.schedulers.Schedulers;
+
+import static junit.framework.Assert.assertNotSame;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
+
+public final class RxAndroidHooksTest {
+
+    @Before @After
+    public void setUpAndTearDown() {
+        RxAndroidHooks.reset();
+        AndroidSchedulers.reset();
+        RxAndroidPlugins.getInstance().reset();
+    }
+
+    @Test
+    public void overrideMainScheduler() {
+        final Scheduler emptyScheduler = new EmptyScheduler();
+        RxAndroidPlugins.getInstance().registerSchedulersHook(new RxAndroidSchedulersHook() {
+            @Override
+            public Scheduler getMainThreadScheduler() {
+                return emptyScheduler;
+            }
+        });
+
+        try {
+            RxAndroidHooks.setOnMainScheduler(new Func1<Scheduler, Scheduler>() {
+                @Override
+                public Scheduler call(Scheduler scheduler) {
+                    return Schedulers.immediate();
+                }
+            });
+            assertSame(Schedulers.immediate(), AndroidSchedulers.mainThread());
+        } finally {
+            RxAndroidHooks.reset();
+        }
+
+        // make sure the reset worked
+        assertNotSame(Schedulers.immediate(), AndroidSchedulers.mainThread());
+    }
+
+    @Test
+    public void lockdown() {
+        RxAndroidHooks.lockdown();
+
+        assertTrue(RxAndroidHooks.isLockdown());
+
+        final Scheduler emptyScheduler = new EmptyScheduler();
+        RxAndroidPlugins.getInstance().registerSchedulersHook(new RxAndroidSchedulersHook() {
+            @Override
+            public Scheduler getMainThreadScheduler() {
+                return emptyScheduler;
+            }
+        });
+
+        try {
+            RxAndroidHooks.setOnMainScheduler(new Func1<Scheduler, Scheduler>() {
+                @Override
+                public Scheduler call(Scheduler scheduler) {
+                    return Schedulers.immediate();
+                }
+            });
+            assertSame(emptyScheduler, AndroidSchedulers.mainThread());
+        } finally {
+            RxAndroidHooks.reset();
+        }
+    }
+}

--- a/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
+++ b/rxandroid/src/test/java/rx/android/schedulers/AndroidSchedulersTest.java
@@ -17,6 +17,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import rx.Scheduler;
+import rx.android.plugins.RxAndroidHooks;
 import rx.android.plugins.RxAndroidPlugins;
 import rx.android.plugins.RxAndroidSchedulersHook;
 import rx.android.testutil.EmptyScheduler;


### PR DESCRIPTION
The little bit inconsistent between `RxJavaHooks` API and current `RxAndroidPlugins` bothers me sometimes. I know RxJava just reached 2.0-RC2 and RxAndroid 2.0 follows the API changes closely, but for the time being, maybe it's a good idea to make RxAndroid 1.x APIs similar with RxJava 1.x's?

I am not sure what to do with `RxAndroidSchedulersHook#onSchedule` though. In my implementation, RxAndroid internally now uses `RxJavaHooks#onScheduledAction`. However, this is a breaking change for people using the API, as you probably can tell from the changes in `LooperSchedulerTest`. I would suggest just removing the `RxAndroidSchedulersHook#onSchedule`, and mentioning using `RxJavaHooks#onScheduledAction` somewhere in the docs or change log? Another approach would be implementing `RxAndroidHooks#onMainScheduledAction`?
