### PR TITLE
2.x: Add lazy loading of default main Scheduler

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/android/plugins/RxAndroidPlugins.java
+++ b/rxandroid/src/main/java/io/reactivex/android/plugins/RxAndroidPlugins.java
@@ -16,9 +16,8 @@ package io.reactivex.android.plugins;
 import java.util.concurrent.Callable;
 
 import io.reactivex.Scheduler;
+import io.reactivex.exceptions.Exceptions;
 import io.reactivex.functions.Function;
-import io.reactivex.internal.functions.ObjectHelper;
-import io.reactivex.internal.util.ExceptionHelper;
 
 /**
  * Utility class to inject handlers to certain standard RxAndroid operations.
@@ -33,7 +32,9 @@ public final class RxAndroidPlugins {
     }
 
     public static Scheduler initMainThreadScheduler(Callable<Scheduler> scheduler) {
-        ObjectHelper.requireNonNull(scheduler, "Scheduler Callable can't be null");
+        if(scheduler == null) {
+            throw new NullPointerException("scheduler == null");
+        }
         Function<Callable<Scheduler>, Scheduler> f = onInitMainThreadHandler;
         if (f == null) {
             return callRequireNonNull(scheduler);
@@ -46,7 +47,9 @@ public final class RxAndroidPlugins {
     }
 
     public static Scheduler onMainThreadScheduler(Scheduler scheduler) {
-        ObjectHelper.requireNonNull(scheduler, "Scheduler can't be null");
+        if(scheduler == null) {
+            throw new NullPointerException("scheduler == null");
+        }
         Function<Scheduler, Scheduler> f = onMainThreadHandler;
         if (f == null) {
             return scheduler;
@@ -64,21 +67,29 @@ public final class RxAndroidPlugins {
 
     static Scheduler callRequireNonNull(Callable<Scheduler> s) {
         try {
-            return ObjectHelper.requireNonNull(s.call(), "Scheduler Callable result can't be null");
+            Scheduler scheduler = s.call();
+            if(scheduler == null) {
+                throw new NullPointerException("Scheduler Callable returned null");
+            }
+            return scheduler;
         } catch (Throwable ex) {
-            throw ExceptionHelper.wrapOrThrow(ex);
+            throw Exceptions.propagate(ex);
         }
     }
 
     static Scheduler applyRequireNonNull(Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
-          return ObjectHelper.requireNonNull(apply(f, s), "Scheduler Callable result can't be null");
+        Scheduler scheduler = apply(f,s);
+        if(scheduler == null) {
+            throw new NullPointerException("Scheduler Callable returned null");
+        }
+        return scheduler;
     }
 
     static <T, R> R apply(Function<T, R> f, T t) {
         try {
             return f.apply(t);
         } catch (Throwable ex) {
-            throw ExceptionHelper.wrapOrThrow(ex);
+            throw Exceptions.propagate(ex);
         }
     }
 

--- a/rxandroid/src/main/java/io/reactivex/android/plugins/RxAndroidPlugins.java
+++ b/rxandroid/src/main/java/io/reactivex/android/plugins/RxAndroidPlugins.java
@@ -32,7 +32,7 @@ public final class RxAndroidPlugins {
     }
 
     public static Scheduler initMainThreadScheduler(Callable<Scheduler> scheduler) {
-        if(scheduler == null) {
+        if (scheduler == null) {
             throw new NullPointerException("scheduler == null");
         }
         Function<Callable<Scheduler>, Scheduler> f = onInitMainThreadHandler;
@@ -47,7 +47,7 @@ public final class RxAndroidPlugins {
     }
 
     public static Scheduler onMainThreadScheduler(Scheduler scheduler) {
-        if(scheduler == null) {
+        if (scheduler == null) {
             throw new NullPointerException("scheduler == null");
         }
         Function<Scheduler, Scheduler> f = onMainThreadHandler;
@@ -68,7 +68,7 @@ public final class RxAndroidPlugins {
     static Scheduler callRequireNonNull(Callable<Scheduler> s) {
         try {
             Scheduler scheduler = s.call();
-            if(scheduler == null) {
+            if (scheduler == null) {
                 throw new NullPointerException("Scheduler Callable returned null");
             }
             return scheduler;
@@ -79,7 +79,7 @@ public final class RxAndroidPlugins {
 
     static Scheduler applyRequireNonNull(Function<Callable<Scheduler>, Scheduler> f, Callable<Scheduler> s) {
         Scheduler scheduler = apply(f,s);
-        if(scheduler == null) {
+        if (scheduler == null) {
             throw new NullPointerException("Scheduler Callable returned null");
         }
         return scheduler;

--- a/rxandroid/src/main/java/io/reactivex/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/io/reactivex/android/schedulers/AndroidSchedulers.java
@@ -15,13 +15,26 @@ package io.reactivex.android.schedulers;
 
 import android.os.Handler;
 import android.os.Looper;
+
+import java.util.concurrent.Callable;
+
 import io.reactivex.Scheduler;
 import io.reactivex.android.plugins.RxAndroidPlugins;
 
 /** Android-specific Schedulers. */
 public final class AndroidSchedulers {
+
+    private static final class MainHolder {
+
+        static final Scheduler DEFAULT = new HandlerScheduler(new Handler(Looper.getMainLooper()));
+    }
+
     private static final Scheduler MAIN_THREAD = RxAndroidPlugins.initMainThreadScheduler(
-        new HandlerScheduler(new Handler(Looper.getMainLooper())));
+            new Callable<Scheduler>() {
+                @Override public Scheduler call() throws Exception {
+                    return MainHolder.DEFAULT;
+                }
+            });
 
     /** A {@link Scheduler} which executes actions on the Android main thread. */
     public static Scheduler mainThread() {

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -165,7 +165,6 @@ public final class RxAndroidPluginsTest {
 
         } catch (NullPointerException npe) {
             assertEquals("Scheduler Callable result can't be null", npe.getMessage());
-
         }
     }
 

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -154,7 +154,6 @@ public final class RxAndroidPluginsTest {
         try {
             RxAndroidPlugins.initMainThreadScheduler(nullResultCallable);
             fail();
-
         } catch (NullPointerException e) {
             assertEquals("Scheduler Callable returned null", e.getMessage());
         }

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -137,7 +137,6 @@ public final class RxAndroidPluginsTest {
         try {
             RxAndroidPlugins.initMainThreadScheduler(null);
             fail();
-
         } catch (NullPointerException e) {
             assertEquals("scheduler == null", e.getMessage());
         }

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -97,7 +97,7 @@ public final class RxAndroidPluginsTest {
         RxAndroidPlugins
                 .setInitMainThreadSchedulerHandler(new Function<Callable<Scheduler>, Scheduler>() {
                     @Override public Scheduler apply(Callable<Scheduler> scheduler) {
-                        throw new RuntimeException();
+                        throw new AssertionError();
                     }
                 });
 
@@ -116,13 +116,13 @@ public final class RxAndroidPluginsTest {
 
     @Test
     public void defaultMainThreadSchedulerIsInitializedLazily() {
-        final Function<Callable<Scheduler>, Scheduler> safeOverride =
+        Function<Callable<Scheduler>, Scheduler> safeOverride =
                 new Function<Callable<Scheduler>, Scheduler>() {
             @Override public Scheduler apply(Callable<Scheduler> __) {
                 return new EmptyScheduler();
             }
         };
-        final Callable<Scheduler> unsafeDefault = new Callable<Scheduler>() {
+        Callable<Scheduler> unsafeDefault = new Callable<Scheduler>() {
             @Override public Scheduler call() throws Exception {
                 throw new AssertionError();
             }

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -84,7 +84,7 @@ public final class RxAndroidPluginsTest {
 
         Callable<Scheduler> scheduler = new Callable<Scheduler>() {
             @Override public Scheduler call() throws Exception {
-                return new EmptyScheduler();
+                throw new AssertionError();
             }
         };
         Scheduler actual = RxAndroidPlugins.initMainThreadScheduler(scheduler);
@@ -116,36 +116,30 @@ public final class RxAndroidPluginsTest {
 
     @Test
     public void defaultMainThreadSchedulerIsInitializedLazily() {
-        final Function<Callable<Scheduler>, Scheduler> safeOverride = new Function<Callable<Scheduler>, Scheduler>() {
+        final Function<Callable<Scheduler>, Scheduler> safeOverride =
+                new Function<Callable<Scheduler>, Scheduler>() {
             @Override public Scheduler apply(Callable<Scheduler> __) {
                 return new EmptyScheduler();
             }
         };
         final Callable<Scheduler> unsafeDefault = new Callable<Scheduler>() {
             @Override public Scheduler call() throws Exception {
-                throw new AssertionError(
-                        "Default Scheduler instance should not have been evaluated");
+                throw new AssertionError();
             }
         };
 
-        // unsafe default Scheduler Callable should not be evaluated when overriding
-        try {
-            RxAndroidPlugins.setInitMainThreadSchedulerHandler(safeOverride);
-            RxAndroidPlugins.initMainThreadScheduler(unsafeDefault);
-        } finally {
-            RxAndroidPlugins.reset();
-        }
+       RxAndroidPlugins.setInitMainThreadSchedulerHandler(safeOverride);
+       RxAndroidPlugins.initMainThreadScheduler(unsafeDefault);
     }
 
     @Test
     public void overrideInitMainSchedulerThrowsWhenSchedulerCallableIsNull() {
-        // fail when Callable is null
         try {
             RxAndroidPlugins.initMainThreadScheduler(null);
-            fail("Should have thrown NullPointerException");
+            fail();
 
-        } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable can't be null", npe.getMessage());
+        } catch (NullPointerException e) {
+            assertEquals("scheduler == null", e.getMessage());
         }
     }
 
@@ -157,13 +151,12 @@ public final class RxAndroidPluginsTest {
             }
         };
 
-        // fail when Callable result is null
         try {
             RxAndroidPlugins.initMainThreadScheduler(nullResultCallable);
-            fail("Should have thrown NullPointerException");
+            fail();
 
-        } catch (NullPointerException npe) {
-            assertEquals("Scheduler Callable result can't be null", npe.getMessage());
+        } catch (NullPointerException e) {
+            assertEquals("Scheduler Callable returned null", e.getMessage());
         }
     }
 

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -118,7 +118,7 @@ public final class RxAndroidPluginsTest {
     public void defaultMainThreadSchedulerIsInitializedLazily() {
         Function<Callable<Scheduler>, Scheduler> safeOverride =
                 new Function<Callable<Scheduler>, Scheduler>() {
-            @Override public Scheduler apply(Callable<Scheduler> __) {
+            @Override public Scheduler apply(Callable<Scheduler> scheduler) {
                 return new EmptyScheduler();
             }
         };

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.reactivex.Scheduler;
 import io.reactivex.android.testutil.EmptyScheduler;
 import io.reactivex.functions.Function;
-import io.reactivex.schedulers.Schedulers;
 
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertEquals;
@@ -119,7 +118,7 @@ public final class RxAndroidPluginsTest {
     public void defaultMainThreadSchedulerIsInitializedLazily() {
         final Function<Callable<Scheduler>, Scheduler> safeOverride = new Function<Callable<Scheduler>, Scheduler>() {
             @Override public Scheduler apply(Callable<Scheduler> __) {
-                return Schedulers.single();
+                return new EmptyScheduler();
             }
         };
         final Callable<Scheduler> unsafeDefault = new Callable<Scheduler>() {

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -152,7 +152,6 @@ public final class RxAndroidPluginsTest {
 
     @Test
     public void overrideInitMainSchedulerThrowsWhenSchedulerCallableReturnsNull() {
-
         Callable<Scheduler> nullResultCallable = new Callable<Scheduler>() {
             @Override public Scheduler call() throws Exception {
                 return null;
@@ -168,7 +167,6 @@ public final class RxAndroidPluginsTest {
             assertEquals("Scheduler Callable result can't be null", npe.getMessage());
 
         }
-
     }
 
 }

--- a/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
+++ b/rxandroid/src/test/java/io/reactivex/android/plugins/RxAndroidPluginsTest.java
@@ -60,7 +60,7 @@ public final class RxAndroidPluginsTest {
     public void resetClearsMainThreadHandler() {
         RxAndroidPlugins.setMainThreadSchedulerHandler(new Function<Scheduler, Scheduler>() {
             @Override public Scheduler apply(Scheduler scheduler) {
-                throw new RuntimeException();
+                throw new AssertionError();
             }
         });
         RxAndroidPlugins.reset();


### PR DESCRIPTION
Initial proposal to address #332 

I've essentially used the same implementation as in RxJava: https://github.com/ReactiveX/RxJava/pull/4585.

For the sake of common implementation, I've used RxJava's internal(?) classes `ObjectHelper` and `ExceptionHelper`. Happy to consider alternatives if we don't want this.
