### PR TITLE
Sync HandlerScheduler error handling with RxJava impl.

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
+++ b/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
@@ -108,11 +108,7 @@ final class HandlerScheduler extends Scheduler {
             try {
                 delegate.run();
             } catch (Throwable t) {
-                IllegalStateException ie =
-                    new IllegalStateException("Fatal Exception thrown on Scheduler.", t);
-                RxJavaPlugins.onError(ie);
-                Thread thread = Thread.currentThread();
-                thread.getUncaughtExceptionHandler().uncaughtException(thread, ie);
+                RxJavaPlugins.onError(t);
             }
         }
 


### PR DESCRIPTION
This PR syncs error handling of `HandlerScheduler` with [error handling of RxJava schedulers](https://github.com/ReactiveX/RxJava/blob/357fac2ebe43029282ff356fa2dfb72b51982104/src/main/java/io/reactivex/internal/schedulers/ScheduledRunnable.java#L64) by simply delivering exception *as is* to the RxJavaPlugins' error handler.

RxJavaPlugins not only delivers exception to the `Thread.UncaughtExceptionHandler` by default, but also allows user to actually override and customize this behavior. 
Current RxAndroid implementation delivers exception to `UncaughtExceptionHandler` unconditionally.

Resolves #390.

@akarnokd, @JakeWharton PTAL