### PR TITLE
Remove superfluous negative check.

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
+++ b/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
@@ -69,7 +69,7 @@ final class HandlerScheduler extends Scheduler {
             Message message = Message.obtain(handler, scheduled);
             message.obj = this; // Used as token for batch disposal of this worker's runnables.
 
-            handler.sendMessageDelayed(message, Math.max(0L, unit.toMillis(delay)));
+            handler.sendMessageDelayed(message, unit.toMillis(delay));
 
             // Re-check disposed state for removing in case we were racing a call to dispose().
             if (disposed) {


### PR DESCRIPTION
Handler does this check already since 2009 when AOSP was imported to git (aka forever).