### PR TITLE
fix spelling, add tailing slash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,9 +25,9 @@ The sections below contain the changes since 2.0.0-RC1.
 
 RxAndroid 2.0 has been rewritten from scratch to support RxJava 2.0.
 
-The library still offers the same APIs: a scheduler and stream cancelation callback that know about
+The library still offers the same APIs: a scheduler and stream cancellation callback that know about
 the main thread, a means of creating a scheduler from any `Looper`, and plugin support for the
-main thread sheduler. They just reside in a new package, `io.reactivex.android`, and may have
+main thread scheduler. They just reside in a new package, `io.reactivex.android`, and may have
 slightly different names.
 
 For more information about RxJava 2.0 see

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ The sections below contain the changes since 2.0.0-RC1.
 
 RxAndroid 2.0 has been rewritten from scratch to support RxJava 2.0.
 
-The library still offers the same APIs: a scheduler and stream cancellation callback that know about
+The library still offers the same APIs: a scheduler and stream cancelation callback that know about
 the main thread, a means of creating a scheduler from any `Looper`, and plugin support for the
 main thread scheduler. They just reside in a new package, `io.reactivex.android`, and may have
 slightly different names.

--- a/gradle/artifacts.gradle
+++ b/gradle/artifacts.gradle
@@ -30,7 +30,7 @@ if (project.plugins.hasPlugin('com.android.library')) {
             }
         }
 
-        // For official releasese, don't prefix the name so the artifact is published correctly
+        // For official releases, don't prefix the name so the artifact is published correctly
         // (Can't seem to modify it for publishing, for whatever reason...)
         String classifierPrefix = (variant.name == 'release') ? '' : "$variant.name-"
 

--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -114,7 +114,7 @@ bintray {
         userOrg = 'reactivex'
         licenses = ['Apache-2.0']
         labels = ['rxjava', 'reactivex']
-        websiteUrl = 'https://github.com/ReactiveX/RxAndroid'
+        websiteUrl = 'https://github.com/ReactiveX/RxAndroid/'
         issueTrackerUrl = 'https://github.com/ReactiveX/RxAndroid/issues'
         vcsUrl = 'https://github.com/ReactiveX/RxAndroid.git'
     }

--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -84,7 +84,7 @@ install {
 //
 // Based on NebulaOJOPublishingPlugin (from nebula-bintray-plugin)
 artifactory {
-    contextUrl = 'https://oss.jfrog.org/'
+    contextUrl = 'https://oss.jfrog.org'
 
     publish {
         repository {
@@ -114,9 +114,9 @@ bintray {
         userOrg = 'reactivex'
         licenses = ['Apache-2.0']
         labels = ['rxjava', 'reactivex']
-        websiteUrl = 'https://github.com/ReactiveX/RxAndroid/'
-        issueTrackerUrl = 'https://github.com/ReactiveX/RxAndroid/issues/'
-        vcsUrl = 'https://github.com/ReactiveX/RxAndroid.git/'
+        websiteUrl = 'https://github.com/ReactiveX/RxAndroid'
+        issueTrackerUrl = 'https://github.com/ReactiveX/RxAndroid/issues'
+        vcsUrl = 'https://github.com/ReactiveX/RxAndroid.git'
     }
 }
 

--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -84,7 +84,7 @@ install {
 //
 // Based on NebulaOJOPublishingPlugin (from nebula-bintray-plugin)
 artifactory {
-    contextUrl = 'https://oss.jfrog.org'
+    contextUrl = 'https://oss.jfrog.org/'
 
     publish {
         repository {
@@ -115,8 +115,8 @@ bintray {
         licenses = ['Apache-2.0']
         labels = ['rxjava', 'reactivex']
         websiteUrl = 'https://github.com/ReactiveX/RxAndroid/'
-        issueTrackerUrl = 'https://github.com/ReactiveX/RxAndroid/issues'
-        vcsUrl = 'https://github.com/ReactiveX/RxAndroid.git'
+        issueTrackerUrl = 'https://github.com/ReactiveX/RxAndroid/issues/'
+        vcsUrl = 'https://github.com/ReactiveX/RxAndroid.git/'
     }
 }
 


### PR DESCRIPTION
### fix spelling

1. cancelation -> cancellation
2. sheduler -> scheduler
3. releasese -> releases

### add trailing slash

1. https://oss.jfrog.org -> https://oss.jfrog.org/
2. https://github.com/ReactiveX/RxAndroid/issues -> https://github.com/ReactiveX/RxAndroid/issues/
3. https://github.com/ReactiveX/RxAndroid.git -> https://github.com/ReactiveX/RxAndroid.git/