### PR TITLE
Remove handler callbacks before setting disposed.

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
+++ b/rxandroid/src/main/java/io/reactivex/android/schedulers/HandlerScheduler.java
@@ -96,7 +96,7 @@ final class HandlerScheduler extends Scheduler {
         private final Handler handler;
         private final Runnable delegate;
 
-        private volatile boolean disposed;
+        private volatile boolean disposed; // Tracked solely for isDisposed().
 
         ScheduledRunnable(Handler handler, Runnable delegate) {
             this.handler = handler;
@@ -114,8 +114,8 @@ final class HandlerScheduler extends Scheduler {
 
         @Override
         public void dispose() {
-            disposed = true;
             handler.removeCallbacks(this);
+            disposed = true;
         }
 
         @Override


### PR DESCRIPTION
This change ensures that you can never observe `disposed` being set to `true` inside `run()`. `removeCallbacks` and the mechanism by which a `Looper` retrieves the head of the message queue are both governed by a lock. When `dispose()` is called on a non-main thread taking this lock is the race which determines cancelation and **not** the boolean.

Include a comment emphasizing that the boolean is tracked solely for the purposes of accurate `isDisposed()` reporting.

Refs #424.