### PR TITLE
Comment for posterity why androidx-core isn't used for async

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulers.java
@@ -69,6 +69,10 @@ public final class AndroidSchedulers {
     @SuppressLint("NewApi") // Checking for an @hide API.
     public static Scheduler from(Looper looper, boolean async) {
         if (looper == null) throw new NullPointerException("looper == null");
+
+        // Below code exists in Androidx-core as well, but is left here rather than include an
+        // entire extra dependency.
+        // https://developer.android.com/reference/kotlin/androidx/core/os/MessageCompat?hl=en#setAsynchronous(android.os.Message,%20kotlin.Boolean)
         if (Build.VERSION.SDK_INT < 16) {
             async = false;
         } else if (async && Build.VERSION.SDK_INT < 22) {


### PR DESCRIPTION
From personal experience, this kind of detail pointing to something Official™️ can save developers a lot of headache having to explain to skeptical colleagues.