### PR TITLE
Updating RxJava version: 3.0.0 -> 3.0.3

### DIFF
--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    api 'io.reactivex.rxjava3:rxjava:3.0.0'
+    api 'io.reactivex.rxjava3:rxjava:3.0.3'
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'org.robolectric:robolectric:3.8'


### PR DESCRIPTION
In this PR, I'm updating RxJava dependency version from `3.0.0` to `3.0.3` (the latest one at this moment).