### PR TITLE
Remove unnecessary holder for the singleton of MainScheduler

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulers.java
@@ -24,13 +24,8 @@ import io.reactivex.rxjava3.core.Scheduler;
 /** Android-specific Schedulers. */
 public final class AndroidSchedulers {
 
-    private static final class MainHolder {
-        static final Scheduler DEFAULT
-            = new HandlerScheduler(new Handler(Looper.getMainLooper()), true);
-    }
-
     private static final Scheduler MAIN_THREAD =
-        RxAndroidPlugins.initMainThreadScheduler(() -> MainHolder.DEFAULT);
+        RxAndroidPlugins.initMainThreadScheduler(() -> new HandlerScheduler(new Handler(Looper.getMainLooper()), true));
 
     /**
      * A {@link Scheduler} which executes actions on the Android main thread.


### PR DESCRIPTION
The static field MAIN_THREAD will be initialized first when class AndroidSchedulers load. So field of Holder will be used at the same. There's no need to wrap it with a Holder class.