### PR TITLE
Enable rxAndroid usage on old Android versions

### DIFF
--- a/rxandroid/src/main/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulers.java
+++ b/rxandroid/src/main/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulers.java
@@ -26,7 +26,7 @@ public final class AndroidSchedulers {
 
     private static final class MainHolder {
         static final Scheduler DEFAULT
-            = new HandlerScheduler(new Handler(Looper.getMainLooper()), true);
+            = from(Looper.getMainLooper());
     }
 
     private static final Scheduler MAIN_THREAD =


### PR DESCRIPTION
Where the Message.setAsynchronous was not available