### PR TITLE
dependencies update and replace deprecated method in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:4.7.5'

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,6 @@ allprojects {
 
 ext {
     minSdkVersion = 9
-    compileSdkVersion = 30
+    compileSdkVersion = 31
     sourceCompatibility = JavaVersion.VERSION_1_8
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -36,9 +36,9 @@ android {
 }
 
 dependencies {
-    api 'io.reactivex.rxjava3:rxjava:3.0.8'
+    api 'io.reactivex.rxjava3:rxjava:3.1.0'
 
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.2.1'
 }
 

--- a/rxandroid/src/test/java/io/reactivex/rxjava3/android/MainThreadDisposableTest.java
+++ b/rxandroid/src/test/java/io/reactivex/rxjava3/android/MainThreadDisposableTest.java
@@ -13,7 +13,6 @@
  */
 package io.reactivex.rxjava3.android;
 
-import io.reactivex.rxjava3.android.MainThreadDisposable;
 import io.reactivex.rxjava3.disposables.Disposable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/rxandroid/src/test/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulersTest.java
+++ b/rxandroid/src/test/java/io/reactivex/rxjava3/android/schedulers/AndroidSchedulersTest.java
@@ -19,7 +19,6 @@ import android.os.Message;
 
 import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins;
 import io.reactivex.rxjava3.android.testutil.EmptyScheduler;
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.functions.Function;
 
@@ -96,7 +95,7 @@ public final class AndroidSchedulersTest {
 
     @Test
     public void mainThreadAsyncMessagesByDefault() {
-        ShadowLooper mainLooper = ShadowLooper.getShadowMainLooper();
+        ShadowLooper mainLooper = shadowOf(Looper.getMainLooper());
         mainLooper.pause();
         ShadowMessageQueue mainMessageQueue = shadowOf(Looper.getMainLooper().getQueue());
 
@@ -112,7 +111,7 @@ public final class AndroidSchedulersTest {
 
     @Test
     public void fromAsyncMessagesByDefault() {
-        ShadowLooper mainLooper = ShadowLooper.getShadowMainLooper();
+        ShadowLooper mainLooper = shadowOf(Looper.getMainLooper());
         mainLooper.pause();
         ShadowMessageQueue mainMessageQueue = shadowOf(Looper.getMainLooper().getQueue());
 
@@ -130,7 +129,7 @@ public final class AndroidSchedulersTest {
     public void asyncIgnoredPre16() {
         ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", 14);
 
-        ShadowLooper mainLooper = ShadowLooper.getShadowMainLooper();
+        ShadowLooper mainLooper = shadowOf(Looper.getMainLooper());
         mainLooper.pause();
         ShadowMessageQueue mainMessageQueue = shadowOf(Looper.getMainLooper().getQueue());
 

--- a/rxandroid/src/test/java/io/reactivex/rxjava3/android/schedulers/HandlerSchedulerTest.java
+++ b/rxandroid/src/test/java/io/reactivex/rxjava3/android/schedulers/HandlerSchedulerTest.java
@@ -18,7 +18,6 @@ import android.os.Looper;
 import android.os.Message;
 
 import io.reactivex.rxjava3.android.testutil.CountingRunnable;
-import io.reactivex.rxjava3.android.schedulers.HandlerScheduler;
 import io.reactivex.rxjava3.core.Scheduler;
 import io.reactivex.rxjava3.core.Scheduler.Worker;
 import io.reactivex.rxjava3.disposables.Disposable;
@@ -66,8 +65,8 @@ public final class HandlerSchedulerTest {
         });
     }
 
-    private Scheduler scheduler;
-    private boolean async;
+    private final Scheduler scheduler;
+    private final boolean async;
 
     public HandlerSchedulerTest(boolean async) {
         this.scheduler = new HandlerScheduler(new Handler(Looper.getMainLooper()), async);
@@ -145,7 +144,7 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
     }
@@ -167,7 +166,7 @@ public final class HandlerSchedulerTest {
         // Verify our runnable was passed to the schedulers hook.
         assertSame(counter, runnableRef.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled runnable was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -179,10 +178,10 @@ public final class HandlerSchedulerTest {
         CountingRunnable counter = new CountingRunnable();
         Disposable disposable = scheduler.scheduleDirect(counter, 1, MINUTES);
 
-        idleMainLooper(30, SECONDS);
+        ShadowLooper.idleMainLooper(30, SECONDS);
         disposable.dispose();
 
-        idleMainLooper(30, SECONDS);
+        ShadowLooper.idleMainLooper(30, SECONDS);
         runUiThreadTasks();
         assertEquals(0, counter.get());
     }
@@ -195,15 +194,15 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(3, counter.get());
     }
@@ -226,7 +225,7 @@ public final class HandlerSchedulerTest {
         assertSame(counter, runnableRef.get());
         runnableRef.set(null);
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled action was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -244,17 +243,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         disposable.dispose();
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -276,17 +275,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Dispose will have happened here during the last run() execution.
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -306,17 +305,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Exception will have happened here during the last run() execution.
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -390,7 +389,7 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
     }
@@ -414,7 +413,7 @@ public final class HandlerSchedulerTest {
         // Verify our runnable was passed to the schedulers hook.
         assertSame(counter, runnableRef.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled runnable was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -428,10 +427,10 @@ public final class HandlerSchedulerTest {
         CountingRunnable counter = new CountingRunnable();
         Disposable disposable = worker.schedule(counter, 1, MINUTES);
 
-        idleMainLooper(30, SECONDS);
+        ShadowLooper.idleMainLooper(30, SECONDS);
         disposable.dispose();
 
-        idleMainLooper(30, SECONDS);
+        ShadowLooper.idleMainLooper(30, SECONDS);
         runUiThreadTasks();
         assertEquals(0, counter.get());
     }
@@ -446,15 +445,15 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(3, counter.get());
     }
@@ -479,7 +478,7 @@ public final class HandlerSchedulerTest {
         assertSame(counter, runnableRef.get());
         runnableRef.set(null);
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled action was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -499,17 +498,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         disposable.dispose();
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -533,17 +532,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Dispose will have happened here during the last run() execution.
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -565,17 +564,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Exception will have happened here during the last run() execution.
 
-        idleMainLooper(1, MINUTES);
+        ShadowLooper.idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -821,10 +820,5 @@ public final class HandlerSchedulerTest {
 
         Message message = mainMessageQueue.getHead();
         assertEquals(async, message.isAsynchronous());
-    }
-
-    private static void idleMainLooper(long amount, TimeUnit unit) {
-        // TODO delete this when https://github.com/robolectric/robolectric/pull/2592 is released.
-        ShadowLooper.idleMainLooper(unit.toMillis(amount));
     }
 }

--- a/rxandroid/src/test/java/io/reactivex/rxjava3/android/schedulers/HandlerSchedulerTest.java
+++ b/rxandroid/src/test/java/io/reactivex/rxjava3/android/schedulers/HandlerSchedulerTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.robolectric.Shadows.shadowOf;
+import static org.robolectric.shadows.ShadowLooper.idleMainLooper;
 import static org.robolectric.shadows.ShadowLooper.pauseMainLooper;
 import static org.robolectric.shadows.ShadowLooper.runUiThreadTasks;
 import static org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTasks;
@@ -144,7 +145,7 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
     }
@@ -166,7 +167,7 @@ public final class HandlerSchedulerTest {
         // Verify our runnable was passed to the schedulers hook.
         assertSame(counter, runnableRef.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled runnable was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -178,10 +179,10 @@ public final class HandlerSchedulerTest {
         CountingRunnable counter = new CountingRunnable();
         Disposable disposable = scheduler.scheduleDirect(counter, 1, MINUTES);
 
-        ShadowLooper.idleMainLooper(30, SECONDS);
+        idleMainLooper(30, SECONDS);
         disposable.dispose();
 
-        ShadowLooper.idleMainLooper(30, SECONDS);
+        idleMainLooper(30, SECONDS);
         runUiThreadTasks();
         assertEquals(0, counter.get());
     }
@@ -194,15 +195,15 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(3, counter.get());
     }
@@ -225,7 +226,7 @@ public final class HandlerSchedulerTest {
         assertSame(counter, runnableRef.get());
         runnableRef.set(null);
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled action was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -243,17 +244,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         disposable.dispose();
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -275,17 +276,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Dispose will have happened here during the last run() execution.
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -305,17 +306,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Exception will have happened here during the last run() execution.
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -389,7 +390,7 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
     }
@@ -413,7 +414,7 @@ public final class HandlerSchedulerTest {
         // Verify our runnable was passed to the schedulers hook.
         assertSame(counter, runnableRef.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled runnable was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -427,10 +428,10 @@ public final class HandlerSchedulerTest {
         CountingRunnable counter = new CountingRunnable();
         Disposable disposable = worker.schedule(counter, 1, MINUTES);
 
-        ShadowLooper.idleMainLooper(30, SECONDS);
+        idleMainLooper(30, SECONDS);
         disposable.dispose();
 
-        ShadowLooper.idleMainLooper(30, SECONDS);
+        idleMainLooper(30, SECONDS);
         runUiThreadTasks();
         assertEquals(0, counter.get());
     }
@@ -445,15 +446,15 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(3, counter.get());
     }
@@ -478,7 +479,7 @@ public final class HandlerSchedulerTest {
         assertSame(counter, runnableRef.get());
         runnableRef.set(null);
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         // Verify the scheduled action was the one returned from the hook.
         assertEquals(1, newCounter.get());
@@ -498,17 +499,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         disposable.dispose();
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -532,17 +533,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Dispose will have happened here during the last run() execution.
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }
@@ -564,17 +565,17 @@ public final class HandlerSchedulerTest {
         runUiThreadTasks();
         assertEquals(0, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(1, counter.get());
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
 
         // Exception will have happened here during the last run() execution.
 
-        ShadowLooper.idleMainLooper(1, MINUTES);
+        idleMainLooper(1, MINUTES);
         runUiThreadTasks();
         assertEquals(2, counter.get());
     }

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName '1.0'
     }

--- a/sample-app/src/main/AndroidManifest.xml
+++ b/sample-app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:exported="true">
 
             <intent-filter>
                 <category android:name="android.intent.category.LAUNCHER"/>


### PR DESCRIPTION
- update `RxJava` to 3.1.0
- update `junit` to 4.13.2
- update wrapper to 6.8.3
- update AGP to 4.2.2
- set `compileSdk` and `targetSdk` to 31
- remove unused import in tests
- replace deprecated method in unit tests
- remove `idleMainLooper` in `HandlerSchedulerTest` due to update has been released