### PR TITLE
Bump up rxjava version from 3.1.0 to 3.1.5

### DIFF
--- a/rxandroid/build.gradle
+++ b/rxandroid/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    api 'io.reactivex.rxjava3:rxjava:3.1.0'
+    api 'io.reactivex.rxjava3:rxjava:3.1.5'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.2.1'


### PR DESCRIPTION
Rxjava 3.1.5 uses reactive-stream [1.0.4](https://github.com/ReactiveX/RxJava/blob/v3.1.5/build.gradle#L16)

Closes https://github.com/ReactiveX/RxAndroid/issues/584